### PR TITLE
Add OpenTofu infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# OpenTofu Web App Infrastructure
+
+This configuration provisions an AWS environment for a containerized web application using Fargate and an RDS Postgres database.
+
+## Components
+- VPC with public subnets
+- Security groups for the ALB, ECS tasks and database
+- Application Load Balancer
+- ECS cluster with a task definition containing two containers
+- Fargate service behind the ALB
+- PostgreSQL RDS instance
+
+## Usage
+1. Set the required variables in a `terraform.tfvars` file:
+
+```hcl
+app_image    = "<app image>"
+worker_image = "<worker image>"
+db_password  = "<strong password>"
+```
+
+2. Initialize and apply the configuration using [OpenTofu](https://opentofu.org/):
+
+```bash
+tofu init
+tofu apply
+```
+
+The outputs will display the ALB DNS name and database endpoint.

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,256 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# Networking stack
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.0.1.0/24"
+  availability_zone       = "${var.region}a"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = "10.0.2.0/24"
+  availability_zone       = "${var.region}b"
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}
+
+# Security groups
+resource "aws_security_group" "alb" {
+  name        = "${var.app_name}-alb-sg"
+  description = "Allow HTTP inbound"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "ecs" {
+  name        = "${var.app_name}-ecs-sg"
+  description = "Allow ECS tasks"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 80
+    to_port         = 80
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.app_name}-rds-sg"
+  description = "Allow RDS access from ECS tasks"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 5432
+    to_port         = 5432
+    security_groups = [aws_security_group.ecs.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Application Load Balancer
+resource "aws_lb" "this" {
+  name               = "${var.app_name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+}
+
+resource "aws_lb_target_group" "app" {
+  name     = "${var.app_name}-tg"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = aws_vpc.this.id
+
+  health_check {
+    path = "/"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+# ECS cluster
+resource "aws_ecs_cluster" "this" {
+  name = "${var.app_name}-cluster"
+}
+
+# IAM roles for tasks
+resource "aws_iam_role" "task_execution" {
+  name = "${var.app_name}-task-exec"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "task_exec_policy" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task_with_db" {
+  name = "${var.app_name}-task-db"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "task_db_policy" {
+  role       = aws_iam_role.task_with_db.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+}
+
+# RDS Postgres
+resource "aws_db_subnet_group" "postgres" {
+  name       = "${var.app_name}-db-subnet"
+  subnet_ids = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+}
+
+resource "aws_db_instance" "postgres" {
+  identifier              = "${var.app_name}-db"
+  engine                  = "postgres"
+  instance_class          = "db.t3.micro"
+  username                = "postgres"
+  password                = var.db_password
+  db_subnet_group_name    = aws_db_subnet_group.postgres.name
+  vpc_security_group_ids  = [aws_security_group.rds.id]
+  skip_final_snapshot     = true
+}
+
+# Task definition with two containers
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${var.app_name}"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = "256"
+  memory                   = "512"
+
+  execution_role_arn = aws_iam_role.task_execution.arn
+  task_role_arn      = aws_iam_role.task_with_db.arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "app"
+      image = var.app_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = 80
+          hostPort      = 80
+        }
+      ]
+    },
+    {
+      name  = "worker"
+      image = var.worker_image
+      essential = false
+    }
+  ])
+}
+
+resource "aws_ecs_service" "app" {
+  name            = "${var.app_name}-svc"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+  network_configuration {
+    subnets         = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+    security_groups = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "app"
+    container_port   = 80
+  }
+  depends_on = [aws_lb_listener.http]
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "db_endpoint" {
+  value = aws_db_instance.postgres.address
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,27 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "app_name" {
+  description = "Name prefix for resources"
+  type        = string
+  default     = "webapp"
+}
+
+variable "app_image" {
+  description = "Docker image for the web application"
+  type        = string
+}
+
+variable "worker_image" {
+  description = "Docker image for the worker"
+  type        = string
+}
+
+variable "db_password" {
+  description = "Password for the postgres database"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary
- set up OpenTofu configuration for a basic Fargate web app
- create networking stack, security groups, ALB and ECS cluster
- include a task definition with two containers and RDS Postgres
- document usage in README

## Testing
- `apt-get install -y terraform` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6871dc6a0c98832ca61e7b286e5b1662