### PR TITLE
Add S3 backend with bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,23 @@ app_env = "production"
 coc_api_token = "<clash of clans api token>"
 ```
 
-2. Initialize and apply the configuration using [OpenTofu](https://opentofu.org/):
+2. Bootstrap the backend to create the S3 bucket and DynamoDB table:
 
 ```bash
-tofu init
+tofu -chdir=bootstrap init
+tofu -chdir=bootstrap apply \
+  -var="state_bucket=<state bucket>" \
+  -var="state_table=<state table>"
+```
+
+3. Initialize and apply the main configuration using [OpenTofu](https://opentofu.org/). Pass the backend settings so state is stored remotely:
+
+```bash
+tofu init \
+  -backend-config="bucket=<state bucket>" \
+  -backend-config="key=<app name>/terraform.tfstate" \
+  -backend-config="region=<region>" \
+  -backend-config="dynamodb_table=<state table>"
 tofu apply
 ```
 

--- a/bootstrap/main.tf
+++ b/bootstrap/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_s3_bucket" "state" {
+  bucket = var.state_bucket
+}
+
+resource "aws_s3_bucket_versioning" "state" {
+  bucket = aws_s3_bucket.state.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state" {
+  bucket = aws_s3_bucket.state.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "lock" {
+  name         = var.state_table
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+output "state_bucket" {
+  value = aws_s3_bucket.state.id
+}
+
+output "state_table" {
+  value = aws_dynamodb_table.lock.name
+}

--- a/bootstrap/outputs.tf
+++ b/bootstrap/outputs.tf
@@ -1,0 +1,7 @@
+output "state_bucket" {
+  value = aws_s3_bucket.state.id
+}
+
+output "state_table" {
+  value = aws_dynamodb_table.lock.name
+}

--- a/bootstrap/variables.tf
+++ b/bootstrap/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "state_bucket" {
+  description = "Name of S3 bucket for Terraform state"
+  type        = string
+}
+
+variable "state_table" {
+  description = "Name of DynamoDB table for state locking"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,7 @@ terraform {
       version = "~> 5.0"
     }
   }
+  backend "s3" {}
 }
 
 provider "aws" {

--- a/modules/nat_instance/main.tf
+++ b/modules/nat_instance/main.tf
@@ -58,7 +58,7 @@ resource "aws_instance" "this" {
 
 resource "aws_eip" "nat" {
   domain = "vpc"
-  tags = { Name = "${var.app_name}-nat-eip" }
+  tags   = { Name = "${var.app_name}-nat-eip" }
 }
 
 resource "aws_eip_association" "nat" {


### PR DESCRIPTION
## Summary
- configure the root module to use an S3 backend
- create a new `bootstrap` configuration for the state bucket and DynamoDB lock table
- document backend bootstrapping and initialization steps in README
- run `terraform fmt` and `terraform validate`

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6874068d9644832c940b09f2e5b9934f