### PR TITLE
Fix NAT Fargate IP and separate sync service

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This configuration provisions an AWS environment for a containerized web applica
 - `networking` creates the VPC, public subnets and private subnets for the database
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
-- `ecs` sets up the ECS cluster, task definition and service, CloudWatch log groups and Secrets Manager entries
+- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
 - `nat_instance` provisions a lightweight Amazon Linux 2023 EC2 instance that acts as a NAT. It automatically allocates an Elastic IP so all Fargate tasks egress from a single static address. The instance is reachable via SSH from `static_ip_allowed_ip` using the `static_ip_key_name` key pair for troubleshooting.
 
-Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN`.
+Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN`. The worker talks to the sync service at `static.<app_name>.local`.
 
 ## Usage
 1. Set the required variables in a `terraform.tfvars` file:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
-- `nat_instance` provisions a lightweight Amazon Linux 2023 EC2 instance that acts as a NAT. It automatically allocates an Elastic IP so all Fargate tasks egress from a single static address. The instance is reachable via SSH from `static_ip_allowed_ip` using the `static_ip_key_name` key pair for troubleshooting.
+- `nat_instance` provisions a lightweight Amazon Linux 2023 EC2 instance that acts as a NAT. It automatically allocates an Elastic IP so all Fargate tasks egress from a single static address. The instance is reachable via SSH from `static_ip_allowed_ip` using the `static_ip_key_name` key pair for troubleshooting. The instance starts the iptables service on boot.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN`. The worker talks to the sync service at `static.<app_name>.local`.
 

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ module "ecs" {
   app_env          = var.app_env
   db_endpoint      = module.rds.db_endpoint
   db_password      = var.db_password
-  sync_base        = "http://localhost:8000/sync"
+  sync_base        = "http://static.${var.app_name}.local:8000/sync"
   coc_api_token    = var.coc_api_token
 }
 

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -12,10 +12,10 @@ resource "aws_security_group" "ecs" {
 
   # allow internal access to the static service
   ingress {
-    protocol        = "tcp"
-    from_port       = 8000
-    to_port         = 8000
-    security_groups = [aws_security_group.ecs.id]
+    protocol  = "tcp"
+    from_port = 8000
+    to_port   = 8000
+    self      = true
   }
 
   egress {

--- a/modules/nat_instance/main.tf
+++ b/modules/nat_instance/main.tf
@@ -49,6 +49,7 @@ resource "aws_instance" "this" {
     IF=$(ip route show default | awk '{print $5}')
     iptables -t nat -A POSTROUTING -o "$IF" -j MASQUERADE
     service iptables save
+    systemctl enable --now iptables
     EOT
   user_data_replace_on_change = true
   tags = {


### PR DESCRIPTION
## Summary
- split the sync container into its own ECS task and service
- allow ECS tasks to talk to the sync service over port 8000
- use Cloud Map to register the sync service
- update worker to use internal DNS name
- document the new setup

## Testing
- `terraform init -backend=false`
- `terraform fmt -check -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68741063f314832c8f734d74ef1699eb