### PR TITLE
Add Google OAuth secrets to ECS

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
 - `nat_instance` provisions a lightweight Amazon Linux 2023 EC2 instance that acts as a NAT. It automatically allocates an Elastic IP so all Fargate tasks egress from a single static address. The instance is reachable via SSH from `static_ip_allowed_ip` using the `static_ip_key_name` key pair for troubleshooting. The instance starts the iptables service on boot.
 
-Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN`. The worker talks to the sync service at `static.<app_name>.local`.
+Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN` and Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.
 
 ## Usage
 1. Set the required variables in a `terraform.tfvars` file:
@@ -24,6 +24,8 @@ db_password  = "<strong password>"
 certificate_arn = "<acm certificate arn>"
 app_env = "production"
 coc_api_token = "<clash of clans api token>"
+google_client_id = "<google oauth client id>"
+google_client_secret = "<google oauth client secret>"
 backend_bucket = "<s3 bucket for state>"
 backend_dynamodb_table = "<dynamodb table for locking>"
 ```

--- a/main.tf
+++ b/main.tf
@@ -27,22 +27,24 @@ module "alb" {
 }
 
 module "ecs" {
-  source           = "./modules/ecs"
-  app_name         = var.app_name
-  vpc_id           = module.networking.vpc_id
-  subnet_ids       = module.networking.private_subnet_ids
-  alb_sg_id        = module.alb.alb_sg_id
-  target_group_arn = module.alb.target_group_arn
-  listener_arn     = module.alb.https_listener_arn
-  region           = var.region
-  app_image        = var.app_image
-  worker_image     = var.worker_image
-  static_ip_image  = var.static_ip_image
-  app_env          = var.app_env
-  db_endpoint      = module.rds.db_endpoint
-  db_password      = var.db_password
-  sync_base        = "http://static.${var.app_name}.local:8000/sync"
-  coc_api_token    = var.coc_api_token
+  source               = "./modules/ecs"
+  app_name             = var.app_name
+  vpc_id               = module.networking.vpc_id
+  subnet_ids           = module.networking.private_subnet_ids
+  alb_sg_id            = module.alb.alb_sg_id
+  target_group_arn     = module.alb.target_group_arn
+  listener_arn         = module.alb.https_listener_arn
+  region               = var.region
+  app_image            = var.app_image
+  worker_image         = var.worker_image
+  static_ip_image      = var.static_ip_image
+  app_env              = var.app_env
+  db_endpoint          = module.rds.db_endpoint
+  db_password          = var.db_password
+  sync_base            = "http://static.${var.app_name}.local:8000/sync"
+  coc_api_token        = var.coc_api_token
+  google_client_id     = var.google_client_id
+  google_client_secret = var.google_client_secret
 }
 
 module "rds" {

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -117,6 +117,33 @@ resource "aws_secretsmanager_secret_version" "coc_api_token" {
   secret_string = var.coc_api_token
 }
 
+resource "aws_secretsmanager_secret" "vite_google_client_id" {
+  name = "${var.app_name}-vite-google-client-id"
+}
+
+resource "aws_secretsmanager_secret_version" "vite_google_client_id" {
+  secret_id     = aws_secretsmanager_secret.vite_google_client_id.id
+  secret_string = var.google_client_id
+}
+
+resource "aws_secretsmanager_secret" "google_client_id" {
+  name = "${var.app_name}-google-client-id"
+}
+
+resource "aws_secretsmanager_secret_version" "google_client_id" {
+  secret_id     = aws_secretsmanager_secret.google_client_id.id
+  secret_string = var.google_client_id
+}
+
+resource "aws_secretsmanager_secret" "google_client_secret" {
+  name = "${var.app_name}-google-client-secret"
+}
+
+resource "aws_secretsmanager_secret_version" "google_client_secret" {
+  secret_id     = aws_secretsmanager_secret.google_client_secret.id
+  secret_string = var.google_client_secret
+}
+
 resource "aws_iam_role_policy" "execution_secrets" {
   name = "${var.app_name}-execution-secrets"
   role = aws_iam_role.task_execution.id
@@ -130,7 +157,10 @@ resource "aws_iam_role_policy" "execution_secrets" {
         aws_secretsmanager_secret.app_env.arn,
         aws_secretsmanager_secret.database_url.arn,
         aws_secretsmanager_secret.secret_key.arn
-        , aws_secretsmanager_secret.coc_api_token.arn
+        , aws_secretsmanager_secret.coc_api_token.arn,
+        aws_secretsmanager_secret.vite_google_client_id.arn,
+        aws_secretsmanager_secret.google_client_id.arn,
+        aws_secretsmanager_secret.google_client_secret.arn
       ]
     }]
   })
@@ -202,6 +232,12 @@ resource "aws_ecs_task_definition" "app" {
           awslogs-stream-prefix = "app"
         }
       }
+      secrets = [
+        {
+          name      = "VITE_GOOGLE_CLIENT_ID"
+          valueFrom = aws_secretsmanager_secret.vite_google_client_id.arn
+        }
+      ]
     },
     {
       name      = "worker"
@@ -247,6 +283,14 @@ resource "aws_ecs_task_definition" "app" {
         {
           name      = "COC_API_TOKEN"
           valueFrom = aws_secretsmanager_secret.coc_api_token.arn
+        },
+        {
+          name      = "GOOGLE_CLIENT_ID"
+          valueFrom = aws_secretsmanager_secret.google_client_id.arn
+        },
+        {
+          name      = "GOOGLE_CLIENT_SECRET"
+          valueFrom = aws_secretsmanager_secret.google_client_secret.arn
         }
       ]
     },
@@ -301,6 +345,14 @@ resource "aws_ecs_task_definition" "static" {
         {
           name      = "DATABASE_URL"
           valueFrom = aws_secretsmanager_secret.database_url.arn
+        },
+        {
+          name      = "GOOGLE_CLIENT_ID"
+          valueFrom = aws_secretsmanager_secret.google_client_id.arn
+        },
+        {
+          name      = "GOOGLE_CLIENT_SECRET"
+          valueFrom = aws_secretsmanager_secret.google_client_secret.arn
         }
       ]
     }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -15,3 +15,6 @@ variable "db_password" { type = string }
 variable "sync_base" { type = string }
 
 variable "coc_api_token" { type = string }
+
+variable "google_client_id" { type = string }
+variable "google_client_secret" { type = string }

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,18 @@ variable "coc_api_token" {
   sensitive   = true
 }
 
+variable "google_client_id" {
+  description = "Google OAuth client ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth client secret"
+  type        = string
+  sensitive   = true
+}
+
 variable "db_password" {
   description = "Password for the postgres database"
   type        = string


### PR DESCRIPTION
## Summary
- add variables for Google OAuth credentials
- create Secrets Manager entries for VITE_GOOGLE_CLIENT_ID, GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET
- pass new secrets to app, worker and static tasks
- require new variables when instantiating the ecs module
- document new variables in the README

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform fmt -check -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68742fca37c4832c94fc85b9e36ae684