### PR TITLE
Add VITE_BASE_PATH secret for app task

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ app_env = "production"
 coc_api_token = "<clash of clans api token>"
 google_client_id = "<google oauth client id>"
 google_client_secret = "<google oauth client secret>"
+vite_base_path = "<base path>"
 backend_bucket = "<s3 bucket for state>"
 backend_dynamodb_table = "<dynamodb table for locking>"
 ```

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,7 @@ module "ecs" {
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret
+  vite_base_path       = var.vite_base_path
 }
 
 module "rds" {

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -144,6 +144,15 @@ resource "aws_secretsmanager_secret_version" "google_client_secret" {
   secret_string = var.google_client_secret
 }
 
+resource "aws_secretsmanager_secret" "vite_base_path" {
+  name = "${var.app_name}-vite-base-path"
+}
+
+resource "aws_secretsmanager_secret_version" "vite_base_path" {
+  secret_id     = aws_secretsmanager_secret.vite_base_path.id
+  secret_string = var.vite_base_path
+}
+
 resource "aws_iam_role_policy" "execution_secrets" {
   name = "${var.app_name}-execution-secrets"
   role = aws_iam_role.task_execution.id
@@ -160,7 +169,8 @@ resource "aws_iam_role_policy" "execution_secrets" {
         , aws_secretsmanager_secret.coc_api_token.arn,
         aws_secretsmanager_secret.vite_google_client_id.arn,
         aws_secretsmanager_secret.google_client_id.arn,
-        aws_secretsmanager_secret.google_client_secret.arn
+        aws_secretsmanager_secret.google_client_secret.arn,
+        aws_secretsmanager_secret.vite_base_path.arn
       ]
     }]
   })
@@ -236,6 +246,10 @@ resource "aws_ecs_task_definition" "app" {
         {
           name      = "VITE_GOOGLE_CLIENT_ID"
           valueFrom = aws_secretsmanager_secret.vite_google_client_id.arn
+        },
+        {
+          name      = "VITE_BASE_PATH"
+          valueFrom = aws_secretsmanager_secret.vite_base_path.arn
         }
       ]
     },

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -18,3 +18,5 @@ variable "coc_api_token" { type = string }
 
 variable "google_client_id" { type = string }
 variable "google_client_secret" { type = string }
+
+variable "vite_base_path" { type = string }

--- a/variables.tf
+++ b/variables.tf
@@ -44,6 +44,12 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "vite_base_path" {
+  description = "Base path for the frontend"
+  type        = string
+  sensitive   = true
+}
+
 variable "db_password" {
   description = "Password for the postgres database"
   type        = string


### PR DESCRIPTION
## Summary
- configure Secrets Manager for new `VITE_BASE_PATH` value
- pass `vite_base_path` variable to ECS module
- document new variable in README

## Testing
- `terraform init -backend=false`
- `terraform fmt -check -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6874454f858c832ca291ed5a1442ebb0