### PR TITLE
Add OpenTofu CI workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'qa-*'
+      - 'prod-*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: opentofu/setup-opentofu@v1
+      - name: Set environment
+        run: |
+          if [[ "$GITHUB_REF" == refs/heads/main ]]; then
+            echo "ENVIRONMENT=dev" >> $GITHUB_ENV
+          elif [[ "$GITHUB_REF" == refs/tags/qa-* ]]; then
+            echo "ENVIRONMENT=qa" >> $GITHUB_ENV
+          else
+            echo "ENVIRONMENT=prod" >> $GITHUB_ENV
+          fi
+      - name: Initialize
+        run: cd environments/$ENVIRONMENT && tofu init -input=false
+      - name: Apply
+        run: cd environments/$ENVIRONMENT && tofu apply -auto-approve -input=false
+

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: Validate
+
+on:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: opentofu/setup-opentofu@v1
+      - name: Initialize
+        run: tofu init -backend=false
+      - name: Format
+        run: tofu fmt -check -recursive
+      - name: Validate
+        run: tofu validate
+

--- a/README.md
+++ b/README.md
@@ -60,3 +60,9 @@ terraform init
 terraform apply
 ```
 
+
+## Continuous Integration
+GitHub Actions validate the configuration on every pull request. Formatting and validation are run with OpenTofu.
+
+Pushing to `main` automatically applies the configuration for the `dev` environment. Tags matching `qa-*` or `prod-*` trigger deployments to `qa` and `prod`.
+


### PR DESCRIPTION
## Summary
- adjust deploy workflow so pushes to `main` deploy to `dev`
- require `qa-*` or `prod-*` tags for higher environments
- update README with new deployment strategy

## Testing
- `terraform init -backend=false`
- `terraform fmt -check -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68759072ae44832cb8b98ad252c974f7