### PR TITLE
Improve ECS deployment handling

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -410,6 +410,10 @@ resource "aws_ecs_service" "app" {
   }
   depends_on = [var.listener_arn]
 
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+
+
   lifecycle {
     ignore_changes = [task_definition]
   }
@@ -433,6 +437,8 @@ resource "aws_ecs_service" "worker" {
   }
   depends_on = [var.listener_arn]
 
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
   lifecycle {
     ignore_changes = [task_definition]
   }
@@ -453,6 +459,9 @@ resource "aws_ecs_service" "static" {
   service_registries {
     registry_arn = aws_service_discovery_service.static.arn
   }
+
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
 
   lifecycle {
     ignore_changes = [task_definition]


### PR DESCRIPTION
## Summary
- ensure ECS services keep one task running during updates
- run `terraform fmt` and `terraform validate`

## Testing
- `terraform fmt -check -recursive`
- `terraform init -backend=false`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_6875cc25df64832c939092cb6edb98ff