### PR TITLE
Add frontend S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This configuration provisions an AWS environment for a containerized web applica
 - `rds` creates the Postgres database in the private subnets
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
 - `nat_instance` provisions a lightweight Amazon Linux 2023 EC2 instance that acts as a NAT. It automatically allocates an Elastic IP so all Fargate tasks egress from a single static address. The instance is reachable via SSH from `static_ip_allowed_ip` using the `static_ip_key_name` key pair for troubleshooting. The instance starts the iptables service on boot.
+- `frontend` creates an S3 bucket configured for static website hosting so the web app can be served directly from S3.
+
+The ECS service running the front-end container remains deployed for now to avoid downtime while migrating traffic.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN` and Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.
 
@@ -29,6 +32,7 @@ google_client_id = "<google oauth client id>"
 google_client_secret = "<google oauth client secret>"
 backend_bucket = "<s3 bucket for state>"
 backend_dynamodb_table = "<dynamodb table for locking>"
+frontend_bucket_name = "<s3 bucket for frontend>"
 ```
 
 2. Create the state bucket and DynamoDB table using the helper script. The

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -70,3 +70,8 @@ module "nat_instance" {
   allowed_ip             = var.static_ip_allowed_ip
   key_name               = var.static_ip_key_name
 }
+
+module "frontend" {
+  source      = "../../modules/frontend"
+  bucket_name = var.frontend_bucket_name
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -17,3 +17,11 @@ output "nat_eip_allocation_id" {
 output "nat_instance_id" {
   value = module.nat_instance.nat_instance_id
 }
+
+output "frontend_bucket" {
+  value = module.frontend.bucket_name
+}
+
+output "frontend_url" {
+  value = module.frontend.website_endpoint
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -92,3 +92,8 @@ variable "backend_dynamodb_table" {
   description = "DynamoDB table for state locking"
   type        = string
 }
+
+variable "frontend_bucket_name" {
+  description = "S3 bucket to host the front-end"
+  type        = string
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -70,3 +70,8 @@ module "nat_instance" {
   allowed_ip             = var.static_ip_allowed_ip
   key_name               = var.static_ip_key_name
 }
+
+module "frontend" {
+  source      = "../../modules/frontend"
+  bucket_name = var.frontend_bucket_name
+}

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -17,3 +17,11 @@ output "nat_eip_allocation_id" {
 output "nat_instance_id" {
   value = module.nat_instance.nat_instance_id
 }
+
+output "frontend_bucket" {
+  value = module.frontend.bucket_name
+}
+
+output "frontend_url" {
+  value = module.frontend.website_endpoint
+}

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -92,3 +92,8 @@ variable "backend_dynamodb_table" {
   description = "DynamoDB table for state locking"
   type        = string
 }
+
+variable "frontend_bucket_name" {
+  description = "S3 bucket to host the front-end"
+  type        = string
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -70,3 +70,8 @@ module "nat_instance" {
   allowed_ip             = var.static_ip_allowed_ip
   key_name               = var.static_ip_key_name
 }
+
+module "frontend" {
+  source      = "../../modules/frontend"
+  bucket_name = var.frontend_bucket_name
+}

--- a/environments/qa/outputs.tf
+++ b/environments/qa/outputs.tf
@@ -17,3 +17,11 @@ output "nat_eip_allocation_id" {
 output "nat_instance_id" {
   value = module.nat_instance.nat_instance_id
 }
+
+output "frontend_bucket" {
+  value = module.frontend.bucket_name
+}
+
+output "frontend_url" {
+  value = module.frontend.website_endpoint
+}

--- a/environments/qa/variables.tf
+++ b/environments/qa/variables.tf
@@ -92,3 +92,8 @@ variable "backend_dynamodb_table" {
   description = "DynamoDB table for state locking"
   type        = string
 }
+
+variable "frontend_bucket_name" {
+  description = "S3 bucket to host the front-end"
+  type        = string
+}

--- a/main.tf
+++ b/main.tf
@@ -70,3 +70,8 @@ module "nat_instance" {
   allowed_ip             = var.static_ip_allowed_ip
   key_name               = var.static_ip_key_name
 }
+
+module "frontend" {
+  source      = "./modules/frontend"
+  bucket_name = var.frontend_bucket_name
+}

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -17,12 +17,12 @@ resource "aws_s3_bucket_public_access_block" "this" {
 
 data "aws_iam_policy_document" "public_read" {
   statement {
-    actions    = ["s3:GetObject"]
+    actions = ["s3:GetObject"]
     principals {
       type        = "AWS"
       identifiers = ["*"]
     }
-    resources  = ["${aws_s3_bucket.this.arn}/*"]
+    resources = ["${aws_s3_bucket.this.arn}/*"]
   }
 }
 

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -18,7 +18,10 @@ resource "aws_s3_bucket_public_access_block" "this" {
 data "aws_iam_policy_document" "public_read" {
   statement {
     actions    = ["s3:GetObject"]
-    principals = [{ type = "AWS", identifiers = ["*"] }]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
     resources  = ["${aws_s3_bucket.this.arn}/*"]
   }
 }

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+
+  website {
+    index_document = "index.html"
+    error_document = "index.html"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+data "aws_iam_policy_document" "public_read" {
+  statement {
+    actions    = ["s3:GetObject"]
+    principals = [{ type = "AWS", identifiers = ["*"] }]
+    resources  = ["${aws_s3_bucket.this.arn}/*"]
+  }
+}
+
+resource "aws_s3_bucket_policy" "public" {
+  bucket = aws_s3_bucket.this.id
+  policy = data.aws_iam_policy_document.public_read.json
+}

--- a/modules/frontend/outputs.tf
+++ b/modules/frontend/outputs.tf
@@ -1,0 +1,7 @@
+output "bucket_name" {
+  value = aws_s3_bucket.this.bucket
+}
+
+output "website_endpoint" {
+  value = aws_s3_bucket.this.website_endpoint
+}

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -1,0 +1,1 @@
+variable "bucket_name" { type = string }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,11 @@ output "nat_eip_allocation_id" {
 output "nat_instance_id" {
   value = module.nat_instance.nat_instance_id
 }
+
+output "frontend_bucket" {
+  value = module.frontend.bucket_name
+}
+
+output "frontend_url" {
+  value = module.frontend.website_endpoint
+}

--- a/variables.tf
+++ b/variables.tf
@@ -92,3 +92,8 @@ variable "backend_dynamodb_table" {
   description = "DynamoDB table for state locking"
   type        = string
 }
+
+variable "frontend_bucket_name" {
+  description = "S3 bucket to host the front-end"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- create `frontend` module to host static site in S3
- expose new `frontend_bucket_name` variable
- provision the bucket from each environment
- document the bucket in README

## Testing
- `terraform fmt -check -recursive`
- `tofu validate` *(fails: Module not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876949a9af0832cb4c0b2c8c606eac6