### PR TITLE
Add S3 endpoint to networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This configuration provisions an AWS environment for a containerized web application using Fargate on Graviton (ARM64) and an RDS Postgres database. The code is organised into modules for easier reuse:
 
-- `networking` creates the VPC, public subnets and private subnets for the database
+- `networking` creates the VPC, public and private subnets for the database and sets up VPC
+  endpoints for Secrets Manager, ECR, CloudWatch Logs and S3 so tasks can pull
+  container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -116,6 +116,13 @@ resource "aws_vpc_endpoint" "ecr_dkr" {
   private_dns_enabled = true
 }
 
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = aws_vpc.this.id
+  service_name      = "com.amazonaws.${var.region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [aws_route_table.private.id]
+}
+
 resource "aws_vpc_endpoint" "logs" {
   vpc_id              = aws_vpc.this.id
   service_name        = "com.amazonaws.${var.region}.logs"


### PR DESCRIPTION
## Summary
- add VPC gateway endpoint for S3 so ECS can pull images without Internet
- document the VPC endpoints in the networking module

## Testing
- `terraform init -backend=false` *(fails: command not found)*
- `terraform fmt -check -recursive` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876b6bda188832c9c65503d12e0a783