### PR TITLE
Add CloudFront distribution for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ google_client_secret = "<google oauth client secret>"
 backend_bucket = "<s3 bucket for state>"
 backend_dynamodb_table = "<dynamodb table for locking>"
 frontend_bucket_name = "<s3 bucket for frontend>"
+frontend_domain_names = ["app.example.com"]
+frontend_certificate_arn = "<acm cert arn for frontend>"
 ```
 
 2. Create the state bucket and DynamoDB table using the helper script. The
@@ -52,6 +54,8 @@ tofu apply
 ```
 
 The outputs will display the ALB DNS name, database endpoint and the NAT gateway's public IP and allocation ID.
+
+Use `scripts/invalidate-cloudfront.sh` with the output `frontend_distribution_id` after uploading new files to the bucket to refresh cached content.
 
 ## Environments
 Separate Terraform roots are provided under `environments/dev`, `environments/qa` and `environments/prod`. Each folder uses its own state prefix so the stages are isolated.

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -69,6 +69,8 @@ module "nat_gateway" {
 }
 
 module "frontend" {
-  source      = "../../modules/frontend"
-  bucket_name = var.frontend_bucket_name
+  source          = "../../modules/frontend"
+  bucket_name     = var.frontend_bucket_name
+  domain_names    = var.frontend_domain_names
+  certificate_arn = var.frontend_certificate_arn
 }

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -25,3 +25,11 @@ output "frontend_bucket" {
 output "frontend_url" {
   value = module.frontend.website_endpoint
 }
+
+output "frontend_distribution" {
+  value = module.frontend.distribution_domain_name
+}
+
+output "frontend_distribution_id" {
+  value = module.frontend.distribution_id
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -88,3 +88,15 @@ variable "frontend_bucket_name" {
   description = "S3 bucket to host the front-end"
   type        = string
 }
+
+variable "frontend_domain_names" {
+  description = "Domain names for the front-end CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "frontend_certificate_arn" {
+  description = "ACM certificate ARN for the front-end distribution"
+  type        = string
+  default     = null
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -69,6 +69,8 @@ module "nat_gateway" {
 }
 
 module "frontend" {
-  source      = "../../modules/frontend"
-  bucket_name = var.frontend_bucket_name
+  source          = "../../modules/frontend"
+  bucket_name     = var.frontend_bucket_name
+  domain_names    = var.frontend_domain_names
+  certificate_arn = var.frontend_certificate_arn
 }

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -25,3 +25,11 @@ output "frontend_bucket" {
 output "frontend_url" {
   value = module.frontend.website_endpoint
 }
+
+output "frontend_distribution" {
+  value = module.frontend.distribution_domain_name
+}
+
+output "frontend_distribution_id" {
+  value = module.frontend.distribution_id
+}

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -88,3 +88,15 @@ variable "frontend_bucket_name" {
   description = "S3 bucket to host the front-end"
   type        = string
 }
+
+variable "frontend_domain_names" {
+  description = "Domain names for the front-end CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "frontend_certificate_arn" {
+  description = "ACM certificate ARN for the front-end distribution"
+  type        = string
+  default     = null
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -69,6 +69,8 @@ module "nat_gateway" {
 }
 
 module "frontend" {
-  source      = "../../modules/frontend"
-  bucket_name = var.frontend_bucket_name
+  source          = "../../modules/frontend"
+  bucket_name     = var.frontend_bucket_name
+  domain_names    = var.frontend_domain_names
+  certificate_arn = var.frontend_certificate_arn
 }

--- a/environments/qa/outputs.tf
+++ b/environments/qa/outputs.tf
@@ -25,3 +25,11 @@ output "frontend_bucket" {
 output "frontend_url" {
   value = module.frontend.website_endpoint
 }
+
+output "frontend_distribution" {
+  value = module.frontend.distribution_domain_name
+}
+
+output "frontend_distribution_id" {
+  value = module.frontend.distribution_id
+}

--- a/environments/qa/variables.tf
+++ b/environments/qa/variables.tf
@@ -88,3 +88,15 @@ variable "frontend_bucket_name" {
   description = "S3 bucket to host the front-end"
   type        = string
 }
+
+variable "frontend_domain_names" {
+  description = "Domain names for the front-end CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "frontend_certificate_arn" {
+  description = "ACM certificate ARN for the front-end distribution"
+  type        = string
+  default     = null
+}

--- a/main.tf
+++ b/main.tf
@@ -69,6 +69,8 @@ module "nat_gateway" {
 }
 
 module "frontend" {
-  source      = "./modules/frontend"
-  bucket_name = var.frontend_bucket_name
+  source          = "./modules/frontend"
+  bucket_name     = var.frontend_bucket_name
+  domain_names    = var.frontend_domain_names
+  certificate_arn = var.frontend_certificate_arn
 }

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -30,3 +30,43 @@ resource "aws_s3_bucket_policy" "public" {
   bucket = aws_s3_bucket.this.id
   policy = data.aws_iam_policy_document.public_read.json
 }
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled = true
+
+  origin {
+    domain_name = aws_s3_bucket.this.website_endpoint
+    origin_id   = aws_s3_bucket.this.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = aws_s3_bucket.this.id
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies { forward = "none" }
+    }
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  price_class = "PriceClass_100"
+
+  viewer_certificate {
+    acm_certificate_arn = var.certificate_arn
+    ssl_support_method  = "sni-only"
+  }
+
+  aliases = var.domain_names
+}

--- a/modules/frontend/outputs.tf
+++ b/modules/frontend/outputs.tf
@@ -5,3 +5,11 @@ output "bucket_name" {
 output "website_endpoint" {
   value = aws_s3_bucket.this.website_endpoint
 }
+
+output "distribution_domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}
+
+output "distribution_id" {
+  value = aws_cloudfront_distribution.this.id
+}

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -1,1 +1,11 @@
 variable "bucket_name" { type = string }
+
+variable "domain_names" {
+  type    = list(string)
+  default = []
+}
+
+variable "certificate_arn" {
+  type    = string
+  default = null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,3 +25,11 @@ output "frontend_bucket" {
 output "frontend_url" {
   value = module.frontend.website_endpoint
 }
+
+output "frontend_distribution" {
+  value = module.frontend.distribution_domain_name
+}
+
+output "frontend_distribution_id" {
+  value = module.frontend.distribution_id
+}

--- a/scripts/invalidate-cloudfront.sh
+++ b/scripts/invalidate-cloudfront.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <distribution_id>" >&2
+  exit 1
+fi
+
+aws cloudfront create-invalidation \
+  --distribution-id "$1" \
+  --paths "/*"

--- a/variables.tf
+++ b/variables.tf
@@ -88,3 +88,15 @@ variable "frontend_bucket_name" {
   description = "S3 bucket to host the front-end"
   type        = string
 }
+
+variable "frontend_domain_names" {
+  description = "Domain names for the front-end CloudFront distribution"
+  type        = list(string)
+  default     = []
+}
+
+variable "frontend_certificate_arn" {
+  description = "ACM certificate ARN for the front-end distribution"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Summary
- create a helper script to invalidate CloudFront caches
- expose new variables to configure CloudFront
- add a CloudFront distribution in the frontend module
- pass new variables in each environment
- show distribution info in outputs and README
- run `terraform fmt` and `terraform validate`

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform fmt -check -recursive`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_6876f4c78970832c90a79123be2fea27