### PR TITLE
Forward If-None-Match header through CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `rds` creates the Postgres database in the private subnets
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
-- `frontend` creates an S3 bucket configured for static website hosting so the web app can be served directly from S3.
+- `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
 
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN` and Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -53,6 +53,7 @@ resource "aws_cloudfront_distribution" "this" {
     forwarded_values {
       query_string = false
       cookies { forward = "none" }
+      headers = ["If-None-Match"]
     }
 
     min_ttl     = 0


### PR DESCRIPTION
## Summary
- forward `If-None-Match` header in CloudFront cache behavior
- document updated CloudFront behavior in README

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68773839e2dc832ca6d79152f5ef04c2