### PR TITLE
Add AppSync chat infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
+- `chat` provisions an AppSync API secured with Google Sign-In and a DynamoDB table to store messages.
 
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager including the `COC_API_TOKEN` and Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.
@@ -52,7 +53,7 @@ tofu init
 tofu apply
 ```
 
-The outputs will display the ALB DNS name, database endpoint and the NAT gateway's public IP and allocation ID.
+The outputs will display the ALB DNS name, database endpoint, the NAT gateway's public IP and the AppSync chat API URL.
 
 Use `scripts/invalidate-cloudfront.sh` with the output `frontend_distribution_id` after uploading new files to the bucket to refresh cached content.
 

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -72,3 +72,9 @@ module "frontend" {
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
 }
+
+module "chat" {
+  source           = "../../modules/chat"
+  app_name         = var.app_name
+  google_client_id = var.google_client_id
+}

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -33,3 +33,11 @@ output "frontend_distribution" {
 output "frontend_distribution_id" {
   value = module.frontend.distribution_id
 }
+
+output "chat_api_url" {
+  value = module.chat.api_url
+}
+
+output "chat_table_name" {
+  value = module.chat.table_name
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -72,3 +72,9 @@ module "frontend" {
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
 }
+
+module "chat" {
+  source           = "../../modules/chat"
+  app_name         = var.app_name
+  google_client_id = var.google_client_id
+}

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -33,3 +33,11 @@ output "frontend_distribution" {
 output "frontend_distribution_id" {
   value = module.frontend.distribution_id
 }
+
+output "chat_api_url" {
+  value = module.chat.api_url
+}
+
+output "chat_table_name" {
+  value = module.chat.table_name
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -72,3 +72,9 @@ module "frontend" {
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
 }
+
+module "chat" {
+  source           = "../../modules/chat"
+  app_name         = var.app_name
+  google_client_id = var.google_client_id
+}

--- a/environments/qa/outputs.tf
+++ b/environments/qa/outputs.tf
@@ -33,3 +33,11 @@ output "frontend_distribution" {
 output "frontend_distribution_id" {
   value = module.frontend.distribution_id
 }
+
+output "chat_api_url" {
+  value = module.chat.api_url
+}
+
+output "chat_table_name" {
+  value = module.chat.table_name
+}

--- a/main.tf
+++ b/main.tf
@@ -72,3 +72,9 @@ module "frontend" {
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
 }
+
+module "chat" {
+  source           = "./modules/chat"
+  app_name         = var.app_name
+  google_client_id = var.google_client_id
+}

--- a/modules/chat/main.tf
+++ b/modules/chat/main.tf
@@ -1,0 +1,116 @@
+data "aws_region" "current" {}
+
+resource "aws_dynamodb_table" "messages" {
+  name         = "${var.app_name}-chat-messages"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "channel"
+  range_key    = "ts"
+
+  attribute {
+    name = "channel"
+    type = "S"
+  }
+
+  attribute {
+    name = "ts"
+    type = "S"
+  }
+}
+
+resource "aws_iam_role" "appsync_dynamo" {
+  name = "${var.app_name}-chat-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "appsync.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "dynamo" {
+  name = "${var.app_name}-chat-dynamo"
+  role = aws_iam_role.appsync_dynamo.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["dynamodb:PutItem", "dynamodb:Query"]
+      Resource = aws_dynamodb_table.messages.arn
+    }]
+  })
+}
+
+resource "aws_iam_role" "appsync_logs" {
+  name = "${var.app_name}-appsync-logs"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Effect    = "Allow"
+      Principal = { Service = "appsync.amazonaws.com" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "logs" {
+  role       = aws_iam_role.appsync_logs.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSAppSyncPushToCloudWatchLogs"
+}
+
+
+resource "aws_appsync_graphql_api" "chat" {
+  name                = "${var.app_name}-chat"
+  authentication_type = "OPENID_CONNECT"
+
+  schema = file("${path.module}/schema.graphql")
+
+  openid_connect_config {
+    issuer    = "https://accounts.google.com"
+    client_id = var.google_client_id
+  }
+
+  log_config {
+    field_log_level          = "ERROR"
+    cloudwatch_logs_role_arn = aws_iam_role.appsync_logs.arn
+  }
+
+  xray_enabled = true
+}
+
+resource "aws_appsync_datasource" "messages" {
+  api_id           = aws_appsync_graphql_api.chat.id
+  name             = "MessagesTable"
+  type             = "AMAZON_DYNAMODB"
+  service_role_arn = aws_iam_role.appsync_dynamo.arn
+
+  dynamodb_config {
+    table_name = aws_dynamodb_table.messages.name
+    region     = data.aws_region.current.name
+  }
+}
+
+resource "aws_appsync_resolver" "get_messages" {
+  api_id      = aws_appsync_graphql_api.chat.id
+  type        = "Query"
+  field       = "getMessages"
+  data_source = aws_appsync_datasource.messages.name
+
+  request_template  = <<EOT
+{"version": "2017-02-28", "operation": "Query", "query": {"expression": "channel = :c", "expressionValues": {":c": {"S": "$ctx.args.channel"}}}, "scanIndexForward": false}
+EOT
+  response_template = "$util.toJson($ctx.result.items)"
+}
+
+resource "aws_appsync_resolver" "send_message" {
+  api_id      = aws_appsync_graphql_api.chat.id
+  type        = "Mutation"
+  field       = "sendMessage"
+  data_source = aws_appsync_datasource.messages.name
+
+  request_template  = <<EOT
+{"version": "2017-02-28", "operation": "PutItem", "key": {"channel": {"S": "$ctx.args.channel"}, "ts": {"S": "$util.time.nowISO8601()"}}, "attributeValues": {"userId": {"S": "$ctx.args.userId"}, "content": {"S": "$ctx.args.content"}}}
+EOT
+  response_template = "$util.toJson($ctx.result)"
+}

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -1,0 +1,11 @@
+output "api_url" {
+  value = aws_appsync_graphql_api.chat.uris["GRAPHQL"]
+}
+
+output "api_id" {
+  value = aws_appsync_graphql_api.chat.id
+}
+
+output "table_name" {
+  value = aws_dynamodb_table.messages.name
+}

--- a/modules/chat/schema.graphql
+++ b/modules/chat/schema.graphql
@@ -1,0 +1,25 @@
+type Message {
+  channel: String!
+  ts: AWSDateTime!
+  userId: String!
+  content: String!
+}
+
+type Query {
+  getMessages(channel: String!): [Message]
+}
+
+type Mutation {
+  sendMessage(channel: String!, userId: String!, content: String!): Message
+}
+
+type Subscription {
+  onMessage(channel: String!): Message
+    @aws_subscribe(mutations: ["sendMessage"])
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+  subscription: Subscription
+}

--- a/modules/chat/variables.tf
+++ b/modules/chat/variables.tf
@@ -1,0 +1,2 @@
+variable "app_name" { type = string }
+variable "google_client_id" { type = string }

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,3 +33,11 @@ output "frontend_distribution" {
 output "frontend_distribution_id" {
   value = module.frontend.distribution_id
 }
+
+output "chat_api_url" {
+  value = module.chat.api_url
+}
+
+output "chat_table_name" {
+  value = module.chat.table_name
+}


### PR DESCRIPTION
## Summary
- create a new `chat` module with DynamoDB and AppSync
- wire the chat module into all environments
- output the chat API URL and table name
- document the new module in the README

## Testing
- `terraform fmt -check -recursive`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68789692ed40832ca4b75f34d1a0f6dc