### PR TITLE
Add DynamoDB write access for messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This configuration provisions an AWS environment for a containerized web applica
   container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
-- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
+- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. Tasks can now write chat messages to DynamoDB.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
 - `chat` provisions an AppSync API secured with Google Sign-In and a DynamoDB table to store messages. It can optionally be accessed from a custom domain by providing a certificate and hostname.

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,3 +1,5 @@
+data "aws_caller_identity" "current" {}
+
 resource "aws_security_group" "ecs" {
   name        = "${var.app_name}-ecs-sg"
   description = "Allow ECS tasks"
@@ -88,6 +90,20 @@ resource "aws_iam_role" "task_with_db" {
 resource "aws_iam_role_policy_attachment" "task_db_policy" {
   role       = aws_iam_role.task_with_db.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+}
+
+resource "aws_iam_role_policy" "task_messages_dynamo" {
+  name = "${var.app_name}-messages-dynamo"
+  role = aws_iam_role.task_with_db.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["dynamodb:PutItem"]
+      Resource = "arn:aws:dynamodb:${var.region}:${data.aws_caller_identity.current.account_id}:table/${var.messages_table}"
+    }]
+  })
 }
 
 # Secrets


### PR DESCRIPTION
## Summary
- allow ECS tasks to put items in the chat messages table
- note new capability in README

## Testing
- `terraform fmt -check -recursive`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68795000a8e4832c9fac586d11196960