### PR TITLE
Allow messages service DynamoDB writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This configuration provisions an AWS environment for a containerized web applica
   container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
-- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`.
+- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN so tasks can write to the chat table.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
-- `chat` provisions an AppSync API secured with Google Sign-In and a DynamoDB table to store messages. It can optionally be accessed from a custom domain by providing a certificate and hostname.
+- `chat` provisions an AppSync API secured with Google Sign-In and a DynamoDB table to store messages. It outputs the table name and ARN for use in IAM policies and can optionally be accessed from a custom domain by providing a certificate and hostname.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.
 ## Usage

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -45,6 +45,7 @@ module "ecs" {
   db_password               = var.db_password
   sync_base                 = "http://static.${var.app_name}.local:8000/sync"
   messages_table            = module.chat.table_name
+  messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -45,6 +45,7 @@ module "ecs" {
   db_password               = var.db_password
   sync_base                 = "http://static.${var.app_name}.local:8000/sync"
   messages_table            = module.chat.table_name
+  messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -45,6 +45,7 @@ module "ecs" {
   db_password               = var.db_password
   sync_base                 = "http://static.${var.app_name}.local:8000/sync"
   messages_table            = module.chat.table_name
+  messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -13,3 +13,7 @@ output "table_name" {
 output "events_url" {
   value = "https://${aws_appsync_graphql_api.chat.id}.appsync-realtime-api.${data.aws_region.current.name}.amazonaws.com/graphql"
 }
+
+output "table_arn" {
+  value = aws_dynamodb_table.messages.arn
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -1,3 +1,5 @@
+
+
 resource "aws_security_group" "ecs" {
   name        = "${var.app_name}-ecs-sg"
   description = "Allow ECS tasks"
@@ -88,6 +90,20 @@ resource "aws_iam_role" "task_with_db" {
 resource "aws_iam_role_policy_attachment" "task_db_policy" {
   role       = aws_iam_role.task_with_db.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonRDSFullAccess"
+}
+
+resource "aws_iam_role_policy" "messages_table" {
+  name = "${var.app_name}-messages-table"
+  role = aws_iam_role.task_with_db.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["dynamodb:PutItem"],
+      Resource = var.messages_table_arn
+    }]
+  })
 }
 
 # Secrets

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -16,6 +16,7 @@ variable "db_password" { type = string }
 variable "sync_base" { type = string }
 
 variable "messages_table" { type = string }
+variable "messages_table_arn" { type = string }
 variable "appsync_events_url" { type = string }
 
 variable "coc_api_token" { type = string }


### PR DESCRIPTION
## Summary
- output chat messages table ARN
- pass table ARN to ECS and use it in IAM policy

## Testing
- `terraform fmt -recursive`
- `terraform fmt -check -recursive`
- `terraform init -backend=false` in each env
- `terraform validate` in each env

------
https://chatgpt.com/codex/tasks/task_e_68795000a8e4832c9fac586d11196960