### PR TITLE
Add MESSAGES_TABLE secret to chat service

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -321,7 +321,7 @@ resource "aws_ecs_task_definition" "worker" {
   ])
 
   lifecycle {
-    ignore_changes = [container_definitions[0].image]
+    ignore_changes = [container_definitions]
   }
 }
 
@@ -387,7 +387,7 @@ resource "aws_ecs_task_definition" "static" {
   ])
 
   lifecycle {
-    ignore_changes = [container_definitions[0].image]
+    ignore_changes = [container_definitions]
   }
 }
 
@@ -468,7 +468,7 @@ resource "aws_ecs_task_definition" "messages" {
   ])
 
   lifecycle {
-    ignore_changes = [container_definitions[0].image]
+    ignore_changes = [container_definitions]
   }
 }
 

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -321,7 +321,7 @@ resource "aws_ecs_task_definition" "worker" {
   ])
 
   lifecycle {
-    ignore_changes = [container_definitions]
+    ignore_changes = [container_definitions[0].image]
   }
 }
 
@@ -387,7 +387,7 @@ resource "aws_ecs_task_definition" "static" {
   ])
 
   lifecycle {
-    ignore_changes = [container_definitions]
+    ignore_changes = [container_definitions[0].image]
   }
 }
 
@@ -468,7 +468,7 @@ resource "aws_ecs_task_definition" "messages" {
   ])
 
   lifecycle {
-    ignore_changes = [container_definitions]
+    ignore_changes = [container_definitions[0].image]
   }
 }
 
@@ -543,7 +543,4 @@ resource "aws_ecs_service" "messages" {
   deployment_minimum_healthy_percent = 100
   deployment_maximum_percent         = 200
 
-  lifecycle {
-    ignore_changes = [task_definition]
-  }
 }


### PR DESCRIPTION
## Summary
- keep `MESSAGES_TABLE` secret on the messages task
- ignore only container image updates on all ECS task definitions

## Testing
- `tofu fmt -recursive`
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate` *(fails: missing provider plugins)*

------
https://chatgpt.com/codex/tasks/task_e_687957b9f51c832cb88ec9d7dc71c53d