### PR TITLE
Fix events_url output

### DIFF
--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -11,7 +11,7 @@ output "table_name" {
 }
 
 output "events_url" {
-  value = "https://${aws_appsync_graphql_api.chat.id}.appsync-realtime-api.${data.aws_region.current.name}.amazonaws.com/graphql"
+  value = var.domain_name != null ? "https://${var.domain_name}/graphql" : "https://${aws_appsync_graphql_api.chat.id}.appsync-realtime-api.${data.aws_region.current.name}.amazonaws.com/graphql"
 }
 
 output "table_arn" {


### PR DESCRIPTION
## Summary
- fix chat module events_url when domain name provided

## Testing
- `terraform fmt -check -recursive`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68797bc8d020832caa81447aa23359d8