### PR TITLE
Add AppSync event API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ tofu init
 tofu apply
 ```
 
-The outputs will display the ALB DNS name, database endpoint, the NAT gateway's public IP and the AppSync chat API and events URLs.
+The outputs will display the ALB DNS name, database endpoint, the NAT gateway's public IP and the AppSync chat API, events URL, event API HTTP endpoint and namespace.
 
 Use `scripts/invalidate-cloudfront.sh` with the output `frontend_distribution_id` after uploading new files to the bucket to refresh cached content.
 

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
   messages_table            = module.chat.table_name
   messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
+  event_api_arn             = module.chat.event_api_arn
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -45,3 +45,19 @@ output "chat_table_name" {
 output "chat_events_url" {
   value = module.chat.events_url
 }
+
+output "event_api_http_endpoint" {
+  value = module.chat.event_api_http_endpoint
+}
+
+output "event_api_arn" {
+  value = module.chat.event_api_arn
+}
+
+output "event_namespace" {
+  value = module.chat.event_namespace
+}
+
+output "event_namespace_arn" {
+  value = module.chat.event_namespace_arn
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
   messages_table            = module.chat.table_name
   messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
+  event_api_arn             = module.chat.event_api_arn
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -45,3 +45,19 @@ output "chat_table_name" {
 output "chat_events_url" {
   value = module.chat.events_url
 }
+
+output "event_api_http_endpoint" {
+  value = module.chat.event_api_http_endpoint
+}
+
+output "event_api_arn" {
+  value = module.chat.event_api_arn
+}
+
+output "event_namespace" {
+  value = module.chat.event_namespace
+}
+
+output "event_namespace_arn" {
+  value = module.chat.event_namespace_arn
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
   messages_table            = module.chat.table_name
   messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
+  event_api_arn             = module.chat.event_api_arn
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret

--- a/environments/qa/outputs.tf
+++ b/environments/qa/outputs.tf
@@ -45,3 +45,19 @@ output "chat_table_name" {
 output "chat_events_url" {
   value = module.chat.events_url
 }
+
+output "event_api_http_endpoint" {
+  value = module.chat.event_api_http_endpoint
+}
+
+output "event_api_arn" {
+  value = module.chat.event_api_arn
+}
+
+output "event_namespace" {
+  value = module.chat.event_namespace
+}
+
+output "event_namespace_arn" {
+  value = module.chat.event_namespace_arn
+}

--- a/modules/chat/main.tf
+++ b/modules/chat/main.tf
@@ -80,7 +80,7 @@ resource "aws_appsync_graphql_api" "chat" {
 }
 
 # Event API for SigV4/IAM and OIDC access
-resource "aws_appsync_api" "chat_event" {
+resource "aws_appsync_graphql_api" "chat_event" {
   name     = "${var.app_name}-chat-event"
   api_type = "EVENT"
 
@@ -98,7 +98,7 @@ resource "aws_appsync_api" "chat_event" {
 
 # Namespace for event channels
 resource "aws_appsync_channel_namespace" "chat_groups" {
-  api_id = aws_appsync_api.chat_event.id
+  api_id = aws_appsync_graphql_api.chat_event.id
   name   = "groups"
 }
 
@@ -153,6 +153,6 @@ resource "aws_appsync_domain_name_api_association" "this" {
 resource "aws_appsync_domain_name_api_association" "event" {
   count       = var.domain_name == null ? 0 : 1
   domain_name = aws_appsync_domain_name.this[0].domain_name
-  api_id      = aws_appsync_api.chat_event.id
+  api_id      = aws_appsync_graphql_api.chat_event.id
   api_type    = "EVENT"
 }

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -18,12 +18,14 @@ output "table_arn" {
   value = aws_dynamodb_table.messages.arn
 }
 
+
 output "event_api_http_endpoint" {
-  value = aws_appsync_api.chat_event.uris["EVENT_HTTP"]
+  value = aws_appsync_graphql_api.chat_event.uris["EVENT_HTTP"]
 }
 
+
 output "event_api_arn" {
-  value = aws_appsync_api.chat_event.arn
+  value = aws_appsync_graphql_api.chat_event.arn
 }
 
 output "event_namespace" {

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -17,3 +17,19 @@ output "events_url" {
 output "table_arn" {
   value = aws_dynamodb_table.messages.arn
 }
+
+output "event_api_http_endpoint" {
+  value = aws_appsync_api.chat_event.uris["EVENT_HTTP"]
+}
+
+output "event_api_arn" {
+  value = aws_appsync_api.chat_event.arn
+}
+
+output "event_namespace" {
+  value = aws_appsync_channel_namespace.chat_groups.name
+}
+
+output "event_namespace_arn" {
+  value = aws_appsync_channel_namespace.chat_groups.arn
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -106,6 +106,23 @@ resource "aws_iam_role_policy" "messages_table" {
   })
 }
 
+resource "aws_iam_policy" "event_publish" {
+  name   = "ChatEventPublish"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "appsync:EventPublish"
+      Resource = "${var.event_api_arn}/*"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_event_publish" {
+  role       = aws_iam_role.task_with_db.name
+  policy_arn = aws_iam_policy.event_publish.arn
+}
+
 # Secrets
 resource "aws_secretsmanager_secret" "app_env" {
   name = "${var.app_name}-app-env"

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -18,6 +18,7 @@ variable "sync_base" { type = string }
 variable "messages_table" { type = string }
 variable "messages_table_arn" { type = string }
 variable "appsync_events_url" { type = string }
+variable "event_api_arn" { type = string }
 
 variable "coc_api_token" { type = string }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,3 +45,19 @@ output "chat_table_name" {
 output "chat_events_url" {
   value = module.chat.events_url
 }
+
+output "event_api_http_endpoint" {
+  value = module.chat.event_api_http_endpoint
+}
+
+output "event_api_arn" {
+  value = module.chat.event_api_arn
+}
+
+output "event_namespace" {
+  value = module.chat.event_namespace
+}
+
+output "event_namespace_arn" {
+  value = module.chat.event_namespace_arn
+}


### PR DESCRIPTION
## Summary
- implement EVENT API with IAM and OIDC auth
- add channel namespace and domain association
- output event API endpoints and namespace info
- allow ECS tasks to publish events via IAM policy

## Testing
- `terraform fmt -recursive` *(fails: command not found)*
- `terraform init -backend=false` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879c87ce7b8832c9ef4d793f3c90e1b