### PR TITLE
Update AppSync authentication to IAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN so tasks can write to the chat table.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
-- `chat` provisions an AppSync API secured with Google Sign-In and a DynamoDB table to store messages. It outputs the table name and ARN for use in IAM policies and can optionally be accessed from a custom domain by providing a certificate and hostname.
+- `chat` provisions an AppSync API secured with IAM (SigV4) and a DynamoDB table to store messages. It outputs the table name, ARN and API ARN for use in IAM policies and can optionally be accessed from a custom domain by providing a certificate and hostname.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.
 ## Usage

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
   messages_table            = module.chat.table_name
   messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
+  appsync_api_arn           = module.chat.api_arn
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret
@@ -79,9 +80,8 @@ module "frontend" {
 }
 
 module "chat" {
-  source           = "../../modules/chat"
-  app_name         = var.app_name
-  google_client_id = var.google_client_id
-  domain_name      = var.chat_domain_name
-  certificate_arn  = var.chat_certificate_arn
+  source          = "../../modules/chat"
+  app_name        = var.app_name
+  domain_name     = var.chat_domain_name
+  certificate_arn = var.chat_certificate_arn
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
   messages_table            = module.chat.table_name
   messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
+  appsync_api_arn           = module.chat.api_arn
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret
@@ -79,9 +80,8 @@ module "frontend" {
 }
 
 module "chat" {
-  source           = "../../modules/chat"
-  app_name         = var.app_name
-  google_client_id = var.google_client_id
-  domain_name      = var.chat_domain_name
-  certificate_arn  = var.chat_certificate_arn
+  source          = "../../modules/chat"
+  app_name        = var.app_name
+  domain_name     = var.chat_domain_name
+  certificate_arn = var.chat_certificate_arn
 }

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -47,6 +47,7 @@ module "ecs" {
   messages_table            = module.chat.table_name
   messages_table_arn        = module.chat.table_arn
   appsync_events_url        = module.chat.events_url
+  appsync_api_arn           = module.chat.api_arn
   coc_api_token             = var.coc_api_token
   google_client_id          = var.google_client_id
   google_client_secret      = var.google_client_secret
@@ -79,9 +80,8 @@ module "frontend" {
 }
 
 module "chat" {
-  source           = "../../modules/chat"
-  app_name         = var.app_name
-  google_client_id = var.google_client_id
-  domain_name      = var.chat_domain_name
-  certificate_arn  = var.chat_certificate_arn
+  source          = "../../modules/chat"
+  app_name        = var.app_name
+  domain_name     = var.chat_domain_name
+  certificate_arn = var.chat_certificate_arn
 }

--- a/modules/chat/main.tf
+++ b/modules/chat/main.tf
@@ -62,14 +62,9 @@ resource "aws_iam_role_policy_attachment" "logs" {
 
 resource "aws_appsync_graphql_api" "chat" {
   name                = "${var.app_name}-chat"
-  authentication_type = "OPENID_CONNECT"
+  authentication_type = "AWS_IAM"
 
   schema = file("${path.module}/schema.graphql")
-
-  openid_connect_config {
-    issuer    = "https://accounts.google.com"
-    client_id = var.google_client_id
-  }
 
   log_config {
     field_log_level          = "ERROR"

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -17,3 +17,7 @@ output "events_url" {
 output "table_arn" {
   value = aws_dynamodb_table.messages.arn
 }
+
+output "api_arn" {
+  value = aws_appsync_graphql_api.chat.arn
+}

--- a/modules/chat/variables.tf
+++ b/modules/chat/variables.tf
@@ -1,5 +1,4 @@
 variable "app_name" { type = string }
-variable "google_client_id" { type = string }
 
 variable "domain_name" {
   type    = string

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -106,6 +106,20 @@ resource "aws_iam_role_policy" "messages_table" {
   })
 }
 
+resource "aws_iam_role_policy" "appsync_access" {
+  name = "${var.app_name}-appsync-access"
+  role = aws_iam_role.task_with_db.id
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["appsync:GraphQL"],
+      Resource = "${var.appsync_api_arn}/*"
+    }]
+  })
+}
+
 # Secrets
 resource "aws_secretsmanager_secret" "app_env" {
   name = "${var.app_name}-app-env"

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -18,6 +18,7 @@ variable "sync_base" { type = string }
 variable "messages_table" { type = string }
 variable "messages_table_arn" { type = string }
 variable "appsync_events_url" { type = string }
+variable "appsync_api_arn" { type = string }
 
 variable "coc_api_token" { type = string }
 


### PR DESCRIPTION
## Summary
- switch the Chat AppSync API to AWS_IAM authentication
- expose the AppSync API ARN from the chat module
- grant ECS tasks permission to call the GraphQL API
- pass the new ARN to ECS services in each environment
- remove unused google_client_id variable from the chat module
- document the new IAM based AppSync API

## Testing
- `terraform fmt -check -recursive`
- `terraform init -backend=false` *(fails: undeclared modules)*
- `terraform validate` *(fails in root module as expected)*
- `terraform init -backend=false` and `terraform validate` in `environments/dev`
- `terraform init -backend=false` and `terraform validate` in `environments/qa`
- `terraform init -backend=false` and `terraform validate` in `environments/prod`


------
https://chatgpt.com/codex/tasks/task_e_6879e808a844832c940a554e8590038a