### PR TITLE
Allow messages service to query DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This configuration provisions an AWS environment for a containerized web applica
   container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
-- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN so tasks can write to the chat table.
+- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN so tasks can read and write the chat table.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
 - `chat` provisions an AppSync API secured with IAM (SigV4) and a DynamoDB table to store messages. It outputs the table name, ARN and API ARN for use in IAM policies and can optionally be accessed from a custom domain by providing a certificate and hostname.

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -99,8 +99,11 @@ resource "aws_iam_role_policy" "messages_table" {
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [{
-      Effect   = "Allow",
-      Action   = ["dynamodb:PutItem"],
+      Effect = "Allow",
+      Action = [
+        "dynamodb:PutItem",
+        "dynamodb:Query"
+      ],
       Resource = var.messages_table_arn
     }]
   })


### PR DESCRIPTION
## Summary
- allow ECS messages task role to query the messages DynamoDB table
- document that ECS tasks now read and write the chat table

## Testing
- `terraform fmt -check -recursive`
- `terraform init -backend=false` *(failed: missing provider plugins in root)*
- `terraform init -backend=false` in `environments/dev`
- `terraform validate` in `environments/dev`

------
https://chatgpt.com/codex/tasks/task_e_6879f6b58014832cba88d92d78f7ef3f