### PR TITLE
Refactor secret handling for ECS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,16 @@
 # Guidelines for Codex
 
-This repository contains OpenTofu code for deploying AWS infrastructure.
+This repository contains `OpenTofu` code for deploying AWS infrastructure. 
+You have tofu installed, but no access to deployed resources.
 
 ## Development Guidelines
 - Use 2 spaces for indentation in all `.tf` files.
-- Format configuration with `terraform fmt -recursive` before committing.
+- Format configuration with `tofu fmt -recursive` before committing.
 - Validate configuration using:
   ```bash
-  terraform init -backend=false
-  terraform fmt -check -recursive
-  terraform validate
+  tofu init -backend=false
+  tofu fmt -check -recursive
+  tofu validate
   ```
 
 - Do not modify `.terraform.lock.hcl`.
@@ -22,4 +23,4 @@ This repository contains OpenTofu code for deploying AWS infrastructure.
 
 ## Pull Requests
 - In the PR description, summarize what changed.
-- Mention that `terraform fmt` and `terraform validate` were run.
+- Mention that `tofu fmt` and `tofu validate` were run.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ This configuration provisions an AWS environment for a containerized web applica
   container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
-- `ecs` sets up the ECS cluster, task definitions and services, CloudWatch log groups and Secrets Manager entries. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN so tasks can read and write the chat table.
+- `secrets` stores application configuration in Secrets Manager for the ECS tasks.
+- `ecs` sets up the ECS cluster, task definitions and services. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN and secret ARNs so tasks can read and write the chat table.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
 - `chat` provisions a DynamoDB table used for the chat service. It outputs the table name and ARN for other modules.
 
-Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker talks to the sync service at `static.<app_name>.local`.
+Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker and static tasks also load `COC_EMAIL` and `COC_PASSWORD` from a shared secret. The worker talks to the sync service at `static.<app_name>.local`.
 ## Usage
 1. Set the required variables in a `terraform.tfvars` file:
 

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -111,86 +111,6 @@ resource "aws_iam_role_policy" "messages_table" {
 
 
 # Secrets
-resource "aws_secretsmanager_secret" "app_env" {
-  name = "${var.app_name}-app-env"
-}
-
-resource "aws_secretsmanager_secret_version" "app_env" {
-  secret_id     = aws_secretsmanager_secret.app_env.id
-  secret_string = var.app_env
-}
-
-
-resource "random_password" "secret_key" {
-  length  = 32
-  special = false
-}
-
-resource "aws_secretsmanager_secret" "secret_key" {
-  name = "${var.app_name}-secret-key"
-}
-
-resource "aws_secretsmanager_secret_version" "secret_key" {
-  secret_id     = aws_secretsmanager_secret.secret_key.id
-  secret_string = random_password.secret_key.result
-}
-
-resource "aws_secretsmanager_secret" "database_url" {
-  name = "${var.app_name}-db-url"
-}
-
-resource "aws_secretsmanager_secret_version" "database_url" {
-  secret_id     = aws_secretsmanager_secret.database_url.id
-  secret_string = "postgresql+psycopg://postgres:${var.db_password}@${var.db_endpoint}:5432/postgres"
-}
-
-resource "aws_secretsmanager_secret" "coc_api_token" {
-  name = "${var.app_name}-coc-token"
-}
-
-resource "aws_secretsmanager_secret_version" "coc_api_token" {
-  secret_id     = aws_secretsmanager_secret.coc_api_token.id
-  secret_string = var.coc_api_token
-}
-
-
-resource "aws_secretsmanager_secret" "aws_region" {
-  name = "${var.app_name}-aws-region"
-}
-
-resource "aws_secretsmanager_secret_version" "aws_region" {
-  secret_id     = aws_secretsmanager_secret.aws_region.id
-  secret_string = var.region
-}
-
-resource "aws_secretsmanager_secret" "messages_table" {
-  name = "${var.app_name}-messages-table"
-}
-
-resource "aws_secretsmanager_secret_version" "messages_table" {
-  secret_id     = aws_secretsmanager_secret.messages_table.id
-  secret_string = var.messages_table
-}
-
-
-
-resource "aws_secretsmanager_secret" "google_client_id" {
-  name = "${var.app_name}-google-client-id"
-}
-
-resource "aws_secretsmanager_secret_version" "google_client_id" {
-  secret_id     = aws_secretsmanager_secret.google_client_id.id
-  secret_string = var.google_client_id
-}
-
-resource "aws_secretsmanager_secret" "google_client_secret" {
-  name = "${var.app_name}-google-client-secret"
-}
-
-resource "aws_secretsmanager_secret_version" "google_client_secret" {
-  secret_id     = aws_secretsmanager_secret.google_client_secret.id
-  secret_string = var.google_client_secret
-}
 
 resource "aws_iam_role_policy" "execution_secrets" {
   name = "${var.app_name}-execution-secrets"
@@ -202,14 +122,15 @@ resource "aws_iam_role_policy" "execution_secrets" {
       Effect = "Allow",
       Action = ["secretsmanager:GetSecretValue"],
       Resource = [
-        aws_secretsmanager_secret.app_env.arn,
-        aws_secretsmanager_secret.database_url.arn,
-        aws_secretsmanager_secret.secret_key.arn,
-        aws_secretsmanager_secret.aws_region.arn,
-        aws_secretsmanager_secret.messages_table.arn,
-        aws_secretsmanager_secret.coc_api_token.arn,
-        aws_secretsmanager_secret.google_client_id.arn,
-        aws_secretsmanager_secret.google_client_secret.arn
+        var.app_env_arn,
+        var.database_url_arn,
+        var.secret_key_arn,
+        var.aws_region_arn,
+        var.messages_table_secret_arn,
+        var.coc_api_token_arn,
+        var.google_client_id_arn,
+        var.google_client_secret_arn,
+        "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO"
       ]
     }]
   })
@@ -289,27 +210,35 @@ resource "aws_ecs_task_definition" "worker" {
       secrets = [
         {
           name      = "APP_ENV"
-          valueFrom = aws_secretsmanager_secret.app_env.arn
+          valueFrom = var.app_env_arn
         },
         {
           name      = "DATABASE_URL"
-          valueFrom = aws_secretsmanager_secret.database_url.arn
+          valueFrom = var.database_url_arn
         },
         {
           name      = "SECRET_KEY"
-          valueFrom = aws_secretsmanager_secret.secret_key.arn
+          valueFrom = var.secret_key_arn
         },
         {
           name      = "COC_API_TOKEN"
-          valueFrom = aws_secretsmanager_secret.coc_api_token.arn
+          valueFrom = var.coc_api_token_arn
         },
         {
           name      = "GOOGLE_CLIENT_ID"
-          valueFrom = aws_secretsmanager_secret.google_client_id.arn
+          valueFrom = var.google_client_id_arn
         },
         {
           name      = "GOOGLE_CLIENT_SECRET"
-          valueFrom = aws_secretsmanager_secret.google_client_secret.arn
+          valueFrom = var.google_client_secret_arn
+        },
+        {
+          name      = "COC_EMAIL"
+          valueFrom = "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO:COC_EMAIL::"
+        },
+        {
+          name      = "COC_PASSWORD"
+          valueFrom = "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO:COC_PASSWORD::"
         }
       ]
     }
@@ -363,19 +292,27 @@ resource "aws_ecs_task_definition" "static" {
       secrets = [
         {
           name      = "COC_API_TOKEN"
-          valueFrom = aws_secretsmanager_secret.coc_api_token.arn
+          valueFrom = var.coc_api_token_arn
         },
         {
           name      = "DATABASE_URL"
-          valueFrom = aws_secretsmanager_secret.database_url.arn
+          valueFrom = var.database_url_arn
         },
         {
           name      = "GOOGLE_CLIENT_ID"
-          valueFrom = aws_secretsmanager_secret.google_client_id.arn
+          valueFrom = var.google_client_id_arn
         },
         {
           name      = "GOOGLE_CLIENT_SECRET"
-          valueFrom = aws_secretsmanager_secret.google_client_secret.arn
+          valueFrom = var.google_client_secret_arn
+        },
+        {
+          name      = "COC_EMAIL"
+          valueFrom = "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO:COC_EMAIL::"
+        },
+        {
+          name      = "COC_PASSWORD"
+          valueFrom = "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO:COC_PASSWORD::"
         }
       ]
     }
@@ -428,31 +365,31 @@ resource "aws_ecs_task_definition" "messages" {
       secrets = [
         {
           name      = "APP_ENV"
-          valueFrom = aws_secretsmanager_secret.app_env.arn
+          valueFrom = var.app_env_arn
         },
         {
           name      = "DATABASE_URL"
-          valueFrom = aws_secretsmanager_secret.database_url.arn
+          valueFrom = var.database_url_arn
         },
         {
           name      = "SECRET_KEY"
-          valueFrom = aws_secretsmanager_secret.secret_key.arn
+          valueFrom = var.secret_key_arn
         },
         {
           name      = "AWS_REGION"
-          valueFrom = aws_secretsmanager_secret.aws_region.arn
+          valueFrom = var.aws_region_arn
         },
         {
           name      = "MESSAGES_TABLE"
-          valueFrom = aws_secretsmanager_secret.messages_table.arn
+          valueFrom = var.messages_table_secret_arn
         },
         {
           name      = "GOOGLE_CLIENT_ID"
-          valueFrom = aws_secretsmanager_secret.google_client_id.arn
+          valueFrom = var.google_client_id_arn
         },
         {
           name      = "GOOGLE_CLIENT_SECRET"
-          valueFrom = aws_secretsmanager_secret.google_client_secret.arn
+          valueFrom = var.google_client_secret_arn
         }
       ]
     }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -9,16 +9,15 @@ variable "region" { type = string }
 variable "worker_image" { type = string }
 variable "static_ip_image" { type = string }
 variable "messages_image" { type = string }
-variable "app_env" { type = string }
-variable "db_endpoint" { type = string }
-variable "db_password" { type = string }
 
 variable "sync_base" { type = string }
-
-variable "messages_table" { type = string }
 variable "messages_table_arn" { type = string }
 
-variable "coc_api_token" { type = string }
-
-variable "google_client_id" { type = string }
-variable "google_client_secret" { type = string }
+variable "app_env_arn" { type = string }
+variable "database_url_arn" { type = string }
+variable "secret_key_arn" { type = string }
+variable "aws_region_arn" { type = string }
+variable "messages_table_secret_arn" { type = string }
+variable "coc_api_token_arn" { type = string }
+variable "google_client_id_arn" { type = string }
+variable "google_client_secret_arn" { type = string }

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -1,0 +1,76 @@
+resource "aws_secretsmanager_secret" "app_env" {
+  name = "${var.app_name}-app-env"
+}
+
+resource "aws_secretsmanager_secret_version" "app_env" {
+  secret_id     = aws_secretsmanager_secret.app_env.id
+  secret_string = var.app_env
+}
+
+resource "random_password" "secret_key" {
+  length  = 32
+  special = false
+}
+
+resource "aws_secretsmanager_secret" "secret_key" {
+  name = "${var.app_name}-secret-key"
+}
+
+resource "aws_secretsmanager_secret_version" "secret_key" {
+  secret_id     = aws_secretsmanager_secret.secret_key.id
+  secret_string = random_password.secret_key.result
+}
+
+resource "aws_secretsmanager_secret" "database_url" {
+  name = "${var.app_name}-db-url"
+}
+
+resource "aws_secretsmanager_secret_version" "database_url" {
+  secret_id     = aws_secretsmanager_secret.database_url.id
+  secret_string = "postgresql+psycopg://postgres:${var.db_password}@${var.db_endpoint}:5432/postgres"
+}
+
+resource "aws_secretsmanager_secret" "coc_api_token" {
+  name = "${var.app_name}-coc-token"
+}
+
+resource "aws_secretsmanager_secret_version" "coc_api_token" {
+  secret_id     = aws_secretsmanager_secret.coc_api_token.id
+  secret_string = var.coc_api_token
+}
+
+resource "aws_secretsmanager_secret" "aws_region" {
+  name = "${var.app_name}-aws-region"
+}
+
+resource "aws_secretsmanager_secret_version" "aws_region" {
+  secret_id     = aws_secretsmanager_secret.aws_region.id
+  secret_string = var.region
+}
+
+resource "aws_secretsmanager_secret" "messages_table" {
+  name = "${var.app_name}-messages-table"
+}
+
+resource "aws_secretsmanager_secret_version" "messages_table" {
+  secret_id     = aws_secretsmanager_secret.messages_table.id
+  secret_string = var.messages_table
+}
+
+resource "aws_secretsmanager_secret" "google_client_id" {
+  name = "${var.app_name}-google-client-id"
+}
+
+resource "aws_secretsmanager_secret_version" "google_client_id" {
+  secret_id     = aws_secretsmanager_secret.google_client_id.id
+  secret_string = var.google_client_id
+}
+
+resource "aws_secretsmanager_secret" "google_client_secret" {
+  name = "${var.app_name}-google-client-secret"
+}
+
+resource "aws_secretsmanager_secret_version" "google_client_secret" {
+  secret_id     = aws_secretsmanager_secret.google_client_secret.id
+  secret_string = var.google_client_secret
+}

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -1,0 +1,31 @@
+output "app_env_arn" {
+  value = aws_secretsmanager_secret.app_env.arn
+}
+
+output "secret_key_arn" {
+  value = aws_secretsmanager_secret.secret_key.arn
+}
+
+output "database_url_arn" {
+  value = aws_secretsmanager_secret.database_url.arn
+}
+
+output "coc_api_token_arn" {
+  value = aws_secretsmanager_secret.coc_api_token.arn
+}
+
+output "aws_region_arn" {
+  value = aws_secretsmanager_secret.aws_region.arn
+}
+
+output "messages_table_secret_arn" {
+  value = aws_secretsmanager_secret.messages_table.arn
+}
+
+output "google_client_id_arn" {
+  value = aws_secretsmanager_secret.google_client_id.arn
+}
+
+output "google_client_secret_arn" {
+  value = aws_secretsmanager_secret.google_client_secret.arn
+}

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -1,0 +1,9 @@
+variable "app_name" { type = string }
+variable "region" { type = string }
+variable "app_env" { type = string }
+variable "db_endpoint" { type = string }
+variable "db_password" { type = string }
+variable "messages_table" { type = string }
+variable "coc_api_token" { type = string }
+variable "google_client_id" { type = string }
+variable "google_client_secret" { type = string }


### PR DESCRIPTION
## Summary
- create new `secrets` module to manage Secrets Manager resources
- reference secret ARNs from the ECS module
- load Clash of Clans login secret for worker and static tasks
- wire secrets module into all environments
- document new module and env vars

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false -no-color`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_687fffa97ed0832cb296e74962fe7cce