### PR TITLE
Add chat single-table DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `ecs` sets up the ECS cluster, task definitions and services. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN and secret ARNs so tasks can read and write the chat table.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
-- `chat` provisions a DynamoDB table used for the chat service. It outputs the table name and ARN for other modules.
+- `chat` provisions the legacy messages table and a new single-table design for chat. It outputs both table names and ARNs for other modules.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker and static tasks also load `COC_EMAIL` and `COC_PASSWORD` from a shared secret. The worker talks to the sync service at `static.<app_name>.local`.
 ## Usage
@@ -54,7 +54,7 @@ tofu init
 tofu apply
 ```
 
-The outputs will display the ALB DNS name, database endpoint, the NAT gateway's public IP and the chat table name.
+The outputs will display the ALB DNS name, database endpoint, the NAT gateway's public IP and both chat table names.
 
 Use `scripts/invalidate-cloudfront.sh` with the output `frontend_distribution_id` after uploading new files to the bucket to refresh cached content.
 

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -40,6 +40,7 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_password          = var.db_password
   messages_table       = module.chat.table_name
+  chat_table           = module.chat.v2_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret
@@ -65,6 +66,7 @@ module "ecs" {
   secret_key_arn            = module.secrets.secret_key_arn
   aws_region_arn            = module.secrets.aws_region_arn
   messages_table_secret_arn = module.secrets.messages_table_secret_arn
+  chat_table_secret_arn     = module.secrets.chat_table_secret_arn
   coc_api_token_arn         = module.secrets.coc_api_token_arn
   google_client_id_arn      = module.secrets.google_client_id_arn
   google_client_secret_arn  = module.secrets.google_client_secret_arn

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.v2_table_name
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -40,6 +40,7 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_password          = var.db_password
   messages_table       = module.chat.table_name
+  chat_table           = module.chat.v2_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret
@@ -65,6 +66,7 @@ module "ecs" {
   secret_key_arn            = module.secrets.secret_key_arn
   aws_region_arn            = module.secrets.aws_region_arn
   messages_table_secret_arn = module.secrets.messages_table_secret_arn
+  chat_table_secret_arn     = module.secrets.chat_table_secret_arn
   coc_api_token_arn         = module.secrets.coc_api_token_arn
   google_client_id_arn      = module.secrets.google_client_id_arn
   google_client_secret_arn  = module.secrets.google_client_secret_arn

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.v2_table_name
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -40,6 +40,7 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_password          = var.db_password
   messages_table       = module.chat.table_name
+  chat_table           = module.chat.v2_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret
@@ -65,6 +66,7 @@ module "ecs" {
   secret_key_arn            = module.secrets.secret_key_arn
   aws_region_arn            = module.secrets.aws_region_arn
   messages_table_secret_arn = module.secrets.messages_table_secret_arn
+  chat_table_secret_arn     = module.secrets.chat_table_secret_arn
   coc_api_token_arn         = module.secrets.coc_api_token_arn
   google_client_id_arn      = module.secrets.google_client_id_arn
   google_client_secret_arn  = module.secrets.google_client_secret_arn

--- a/environments/qa/outputs.tf
+++ b/environments/qa/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.v2_table_name
+}

--- a/modules/chat/main.tf
+++ b/modules/chat/main.tf
@@ -16,3 +16,43 @@ resource "aws_dynamodb_table" "messages" {
     type = "S"
   }
 }
+
+resource "aws_dynamodb_table" "chat" {
+  name         = "${var.app_name}-chat-v2"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key  = "PK"
+  range_key = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  attribute {
+    name = "GSI1PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "ttl"
+    type = "N"
+  }
+
+  global_secondary_index {
+    name            = "GSI1"
+    hash_key        = "GSI1PK"
+    range_key       = "SK"
+    projection_type = "ALL"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+}

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -4,3 +4,11 @@ output "table_name" {
 output "table_arn" {
   value = aws_dynamodb_table.messages.arn
 }
+
+output "v2_table_name" {
+  value = aws_dynamodb_table.chat.name
+}
+
+output "v2_table_arn" {
+  value = aws_dynamodb_table.chat.arn
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -127,6 +127,7 @@ resource "aws_iam_role_policy" "execution_secrets" {
         var.secret_key_arn,
         var.aws_region_arn,
         var.messages_table_secret_arn,
+        var.chat_table_secret_arn,
         var.coc_api_token_arn,
         var.google_client_id_arn,
         var.google_client_secret_arn,
@@ -382,6 +383,10 @@ resource "aws_ecs_task_definition" "messages" {
         {
           name      = "MESSAGES_TABLE"
           valueFrom = var.messages_table_secret_arn
+        },
+        {
+          name      = "CHAT_TABLE"
+          valueFrom = var.chat_table_secret_arn
         },
         {
           name      = "GOOGLE_CLIENT_ID"

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -18,6 +18,7 @@ variable "database_url_arn" { type = string }
 variable "secret_key_arn" { type = string }
 variable "aws_region_arn" { type = string }
 variable "messages_table_secret_arn" { type = string }
+variable "chat_table_secret_arn" { type = string }
 variable "coc_api_token_arn" { type = string }
 variable "google_client_id_arn" { type = string }
 variable "google_client_secret_arn" { type = string }

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -57,6 +57,15 @@ resource "aws_secretsmanager_secret_version" "messages_table" {
   secret_string = var.messages_table
 }
 
+resource "aws_secretsmanager_secret" "chat_table" {
+  name = "${var.app_name}-chat-v2-table"
+}
+
+resource "aws_secretsmanager_secret_version" "chat_table" {
+  secret_id     = aws_secretsmanager_secret.chat_table.id
+  secret_string = var.chat_table
+}
+
 resource "aws_secretsmanager_secret" "google_client_id" {
   name = "${var.app_name}-google-client-id"
 }

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -22,6 +22,10 @@ output "messages_table_secret_arn" {
   value = aws_secretsmanager_secret.messages_table.arn
 }
 
+output "chat_table_secret_arn" {
+  value = aws_secretsmanager_secret.chat_table.arn
+}
+
 output "google_client_id_arn" {
   value = aws_secretsmanager_secret.google_client_id.arn
 }

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -4,6 +4,7 @@ variable "app_env" { type = string }
 variable "db_endpoint" { type = string }
 variable "db_password" { type = string }
 variable "messages_table" { type = string }
+variable "chat_table" { type = string }
 variable "coc_api_token" { type = string }
 variable "google_client_id" { type = string }
 variable "google_client_secret" { type = string }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.v2_table_name
+}


### PR DESCRIPTION
## Summary
- add a new chat-v2 table following the single-table design
- store and expose the new chat table name via Secrets Manager
- pass the new secret to ECS tasks
- output both chat table names
- document the new table in the README

## Testing
- `tofu fmt -check -recursive`
- `tofu init -backend=false` and `tofu validate` in each env

------
https://chatgpt.com/codex/tasks/task_e_68804d3edad8832c9043099b5ce27717