### PR TITLE
Add single-table chat design

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ This configuration provisions an AWS environment for a containerized web applica
 - `alb` provisions the Application Load Balancer and related security group
 - `rds` creates the Postgres database in the private subnets
 - `secrets` stores application configuration in Secrets Manager for the ECS tasks.
-- `ecs` sets up the ECS cluster, task definitions and services. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires the DynamoDB table ARN and secret ARNs so tasks can read and write the chat table.
+- `ecs` sets up the ECS cluster, task definitions and services. The sync service is registered in Cloud Map so other tasks can reach it via `static.<app_name>.local`. It now requires both DynamoDB table ARNs and secret ARNs so tasks can read and write the chat tables.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
-- `chat` provisions a DynamoDB table used for the chat service. It outputs the table name and ARN for other modules.
+- `chat` provisions two DynamoDB tables used for the chat service. The existing
+  `messages` table stores one item per message. A new single-table design named
+  `${var.app_name}-chat-v2` is deployed alongside it to prepare for migration.
+  The module outputs the names and ARNs for both tables.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker and static tasks also load `COC_EMAIL` and `COC_PASSWORD` from a shared secret. The worker talks to the sync service at `static.<app_name>.local`.
 ## Usage
@@ -54,7 +57,8 @@ tofu init
 tofu apply
 ```
 
-The outputs will display the ALB DNS name, database endpoint, the NAT gateway's public IP and the chat table name.
+The outputs will display the ALB DNS name, database endpoint, the NAT gateway's
+public IP and both chat table names.
 
 Use `scripts/invalidate-cloudfront.sh` with the output `frontend_distribution_id` after uploading new files to the bucket to refresh cached content.
 

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -60,6 +60,7 @@ module "ecs" {
   messages_image            = var.messages_image
   sync_base                 = "http://static.${var.app_name}.local:8000/sync"
   messages_table_arn        = module.chat.table_arn
+  chat_table_arn            = module.chat.chat_table_arn
   app_env_arn               = module.secrets.app_env_arn
   database_url_arn          = module.secrets.database_url_arn
   secret_key_arn            = module.secrets.secret_key_arn

--- a/environments/dev/outputs.tf
+++ b/environments/dev/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.chat_table_name
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -60,6 +60,7 @@ module "ecs" {
   messages_image            = var.messages_image
   sync_base                 = "http://static.${var.app_name}.local:8000/sync"
   messages_table_arn        = module.chat.table_arn
+  chat_table_arn            = module.chat.chat_table_arn
   app_env_arn               = module.secrets.app_env_arn
   database_url_arn          = module.secrets.database_url_arn
   secret_key_arn            = module.secrets.secret_key_arn

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.chat_table_name
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -60,6 +60,7 @@ module "ecs" {
   messages_image            = var.messages_image
   sync_base                 = "http://static.${var.app_name}.local:8000/sync"
   messages_table_arn        = module.chat.table_arn
+  chat_table_arn            = module.chat.chat_table_arn
   app_env_arn               = module.secrets.app_env_arn
   database_url_arn          = module.secrets.database_url_arn
   secret_key_arn            = module.secrets.secret_key_arn

--- a/environments/qa/outputs.tf
+++ b/environments/qa/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.chat_table_name
+}

--- a/modules/chat/main.tf
+++ b/modules/chat/main.tf
@@ -16,3 +16,43 @@ resource "aws_dynamodb_table" "messages" {
     type = "S"
   }
 }
+
+resource "aws_dynamodb_table" "chat" {
+  name         = "${var.app_name}-chat-v2"
+  billing_mode = "PAY_PER_REQUEST"
+
+  hash_key  = "PK"
+  range_key = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  attribute {
+    name = "GSI1PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "ttl"
+    type = "N"
+  }
+
+  global_secondary_index {
+    name            = "GSI1"
+    hash_key        = "GSI1PK"
+    range_key       = "SK"
+    projection_type = "ALL"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+}

--- a/modules/chat/outputs.tf
+++ b/modules/chat/outputs.tf
@@ -4,3 +4,11 @@ output "table_name" {
 output "table_arn" {
   value = aws_dynamodb_table.messages.arn
 }
+
+output "chat_table_name" {
+  value = aws_dynamodb_table.chat.name
+}
+
+output "chat_table_arn" {
+  value = aws_dynamodb_table.chat.arn
+}

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -104,7 +104,7 @@ resource "aws_iam_role_policy" "messages_table" {
         "dynamodb:PutItem",
         "dynamodb:Query"
       ],
-      Resource = var.messages_table_arn
+      Resource = [var.messages_table_arn, var.chat_table_arn]
     }]
   })
 }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -12,6 +12,7 @@ variable "messages_image" { type = string }
 
 variable "sync_base" { type = string }
 variable "messages_table_arn" { type = string }
+variable "chat_table_arn" { type = string }
 
 variable "app_env_arn" { type = string }
 variable "database_url_arn" { type = string }

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,7 @@ output "frontend_distribution_id" {
 output "chat_table_name" {
   value = module.chat.table_name
 }
+
+output "chat_v2_table_name" {
+  value = module.chat.chat_table_name
+}


### PR DESCRIPTION
## Summary
- add new DynamoDB table using the planned single-table layout
- expose new table name and ARN from the chat module
- output the new table name at the root and in each environment
- document the additional chat table in README
- grant ECS task role permissions to the new table

## Testing
- `tofu fmt -check -recursive`
- `tofu validate` in `environments/dev` (with warnings)


------
https://chatgpt.com/codex/tasks/task_e_68804d3edad8832c9043099b5ce27717