### PR TITLE
Fix chat table output reference

### DIFF
--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -40,7 +40,7 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_password          = var.db_password
   messages_table       = module.chat.table_name
-  chat_table           = module.chat.v2_table_name
+  chat_table           = module.chat.chat_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -40,7 +40,7 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_password          = var.db_password
   messages_table       = module.chat.table_name
-  chat_table           = module.chat.v2_table_name
+  chat_table           = module.chat.chat_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -40,7 +40,7 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_password          = var.db_password
   messages_table       = module.chat.table_name
-  chat_table           = module.chat.v2_table_name
+  chat_table           = module.chat.chat_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
   google_client_secret = var.google_client_secret


### PR DESCRIPTION
## Summary
- reference the correct `chat_table_name` output when passing to secrets module

## Testing
- `tofu fmt -check -recursive`
- `tofu init -backend=false` and `tofu validate` in `environments/dev`


------
https://chatgpt.com/codex/tasks/task_e_68806893e454832c86a44673bcb53e06