### PR TITLE
Update notifications ECS configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `secrets` stores application configuration in Secrets Manager for the ECS tasks.
 - `ecs` sets up the ECS cluster, task definitions and services. The user service is registered in Cloud Map so other tasks can reach it via `user.<app_name>.local` and is exposed through the ALB at `/api/v1/friends`. It now requires the chat table ARN and related secret ARNs so tasks can read and write chat messages.
   The user task also receives database credentials from Secrets Manager.
-- `notifications` connects the chat table stream to an SQS outbox with a Lambda function and exposes VAPID keys for push notifications.
+- `notifications` connects the chat table stream to an SQS outbox with a Lambda function, exposes VAPID keys for push notifications and now outputs the outbox and DLQ queue URLs.
 - `nat_gateway` provides outbound internet access for private subnets using an Elastic IP so Fargate tasks egress from a static address. It requires no maintenance or SSH access.
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
 - `chat` provisions a DynamoDB table used for the chat service with streams enabled. The table name, ARN and stream ARN are exported for other modules.

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -88,6 +88,7 @@ module "ecs" {
   notifications_image            = var.notifications_image
   notifications_queue_url        = module.notifications.queue_url
   notifications_queue_arn        = module.notifications.queue_arn
+  notifications_dlq_url          = module.notifications.dlq_url
   vapid_secret_arn               = module.notifications.vapid_secret_arn
   depends_on                     = [module.alb]
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -88,6 +88,7 @@ module "ecs" {
   notifications_image            = var.notifications_image
   notifications_queue_url        = module.notifications.queue_url
   notifications_queue_arn        = module.notifications.queue_arn
+  notifications_dlq_url          = module.notifications.dlq_url
   vapid_secret_arn               = module.notifications.vapid_secret_arn
   depends_on                     = [module.alb]
 }

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -88,6 +88,7 @@ module "ecs" {
   notifications_image            = var.notifications_image
   notifications_queue_url        = module.notifications.queue_url
   notifications_queue_arn        = module.notifications.queue_arn
+  notifications_dlq_url          = module.notifications.dlq_url
   vapid_secret_arn               = module.notifications.vapid_secret_arn
   depends_on                     = [module.alb]
 }

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -530,8 +530,12 @@ resource "aws_ecs_task_definition" "notifications" {
           value = "8030"
         },
         {
-          name  = "QUEUE_URL"
+          name  = "OUTBOX_QUEUE_URL"
           value = var.notifications_queue_url
+        },
+        {
+          name  = "OUTBOX_DLQ_URL"
+          value = var.notifications_dlq_url
         }
       ]
       logConfiguration = {

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -31,4 +31,5 @@ variable "messages_allowed_origins_name" { type = string }
 variable "user_allowed_origins_name" { type = string }
 variable "notifications_queue_url" { type = string }
 variable "notifications_queue_arn" { type = string }
+variable "notifications_dlq_url" { type = string }
 variable "vapid_secret_arn" { type = string }

--- a/modules/notifications/outputs.tf
+++ b/modules/notifications/outputs.tf
@@ -6,6 +6,10 @@ output "queue_arn" {
   value = aws_sqs_queue.outbox.arn
 }
 
+output "dlq_url" {
+  value = aws_sqs_queue.dlq.url
+}
+
 output "vapid_secret_arn" {
   value = data.aws_secretsmanager_secret.vapid.arn
 }


### PR DESCRIPTION
## Summary
- rename `QUEUE_URL` env var to `OUTBOX_QUEUE_URL`
- expose the notifications DLQ URL and pass to ECS
- add `notifications_dlq_url` variable for ecs module
- document new output in README
- run `tofu fmt` and `tofu validate`

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_688540006314832c9953fb4a4e3e4021