### PR TITLE
Add WAF module and attach to ALB

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This configuration provisions an AWS environment for a containerized web applica
   endpoints for Secrets Manager, ECR, CloudWatch Logs and S3 so tasks can pull
   container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
+- `waf` deploys an AWS WAFv2 Web ACL attached to the ALB
 - `rds` creates the Postgres database in the private subnets
 - `secrets` stores application configuration in Secrets Manager for the ECS tasks.
 - `ecs` sets up the ECS cluster, task definitions and services. The user service is registered in Cloud Map so other tasks can reach it via `user.<app_name>.local` and is exposed through the ALB at `/api/v1/friends`. It now requires the chat table ARN and related secret ARNs so tasks can read and write chat messages.

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -18,6 +18,11 @@ module "networking" {
   app_name = var.app_name
 }
 
+module "waf" {
+  source   = "../../modules/waf"
+  app_name = var.app_name
+}
+
 module "alb" {
   source            = "../../modules/alb"
   app_name          = var.app_name
@@ -25,6 +30,7 @@ module "alb" {
   public_subnet_ids = module.networking.public_subnet_ids
   certificate_arn   = var.certificate_arn
   api_host          = var.api_host
+  waf_web_acl_arn   = module.waf.web_acl_arn
 }
 
 module "chat" {

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -18,6 +18,11 @@ module "networking" {
   app_name = var.app_name
 }
 
+module "waf" {
+  source   = "../../modules/waf"
+  app_name = var.app_name
+}
+
 module "alb" {
   source            = "../../modules/alb"
   app_name          = var.app_name
@@ -25,6 +30,7 @@ module "alb" {
   public_subnet_ids = module.networking.public_subnet_ids
   certificate_arn   = var.certificate_arn
   api_host          = var.api_host
+  waf_web_acl_arn   = module.waf.web_acl_arn
 }
 
 module "chat" {

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -18,6 +18,11 @@ module "networking" {
   app_name = var.app_name
 }
 
+module "waf" {
+  source   = "../../modules/waf"
+  app_name = var.app_name
+}
+
 module "alb" {
   source            = "../../modules/alb"
   app_name          = var.app_name
@@ -25,6 +30,7 @@ module "alb" {
   public_subnet_ids = module.networking.public_subnet_ids
   certificate_arn   = var.certificate_arn
   api_host          = var.api_host
+  waf_web_acl_arn   = module.waf.web_acl_arn
 }
 
 module "chat" {

--- a/modules/alb/main.tf
+++ b/modules/alb/main.tf
@@ -252,3 +252,10 @@ resource "aws_lb_listener_rule" "notifications" {
     }
   }
 }
+
+resource "aws_wafv2_web_acl_association" "this" {
+  count        = var.waf_web_acl_arn == null ? 0 : 1
+  resource_arn = aws_lb.this.arn
+  web_acl_arn  = var.waf_web_acl_arn
+}
+

--- a/modules/alb/variables.tf
+++ b/modules/alb/variables.tf
@@ -6,3 +6,7 @@ variable "api_host" {
   type    = string
   default = null
 }
+variable "waf_web_acl_arn" {
+  type    = string
+  default = null
+}

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -1,0 +1,36 @@
+resource "aws_wafv2_web_acl" "this" {
+  name  = "${var.app_name}-waf"
+  scope = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.app_name}-waf"
+    sampled_requests_enabled   = true
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    override_action {
+      none {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+}

--- a/modules/waf/outputs.tf
+++ b/modules/waf/outputs.tf
@@ -1,0 +1,3 @@
+output "web_acl_arn" {
+  value = aws_wafv2_web_acl.this.arn
+}

--- a/modules/waf/variables.tf
+++ b/modules/waf/variables.tf
@@ -1,0 +1,1 @@
+variable "app_name" { type = string }


### PR DESCRIPTION
## Summary
- create a new `waf` module to deploy an AWS WAFv2 Web ACL
- allow the ALB module to accept a web ACL ARN and attach it
- attach the WAF to the ALB in all environments
- document the new module

## Testing
- `tofu fmt -recursive`
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6887d74d13d0832c8de15140ea902f96