### PR TITLE
Fix WAF blocking OPTIONS requests

### DIFF
--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -13,6 +13,52 @@ resource "aws_wafv2_web_acl" "this" {
   }
 
   rule {
+    name     = "allow-options"
+    priority = 0
+
+    action {
+      allow {}
+    }
+
+    statement {
+      and_statement {
+        statement {
+          byte_match_statement {
+            search_string = "OPTIONS"
+            field_to_match {
+              method {}
+            }
+            positional_constraint = "EXACTLY"
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+        statement {
+          byte_match_statement {
+            search_string = "/api/v1/"
+            field_to_match {
+              uri_path {}
+            }
+            positional_constraint = "STARTS_WITH"
+            text_transformation {
+              priority = 0
+              type     = "NONE"
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "allow-options"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
     name     = "AWS-AWSManagedRulesCommonRuleSet"
     priority = 1
 


### PR DESCRIPTION
## Summary
- allow OPTIONS requests on `/api/v1/` paths in the WAF

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6887ebae3d90832cbe4191777ac4b913