### PR TITLE
Use single secret for tfvars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'dev' || startsWith(github.ref, 'refs/tags/qa-') && 'qa' || 'prod' }}
+    env:
+      ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'dev' || startsWith(github.ref, 'refs/tags/qa-') && 'qa' || 'prod' }}
     steps:
       - uses: actions/checkout@v3
       - uses: opentofu/setup-opentofu@v1
@@ -19,44 +22,10 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
-      - name: Set environment
-        run: |
-          if [[ "$GITHUB_REF" == refs/heads/main ]]; then
-            echo "ENVIRONMENT=dev" >> $GITHUB_ENV
-          elif [[ "$GITHUB_REF" == refs/tags/qa-* ]]; then
-            echo "ENVIRONMENT=qa" >> $GITHUB_ENV
-          else
-            echo "ENVIRONMENT=prod" >> $GITHUB_ENV
-          fi
-      - name: Build tfvars from secrets
-        run: |
-          cat <<EOF > environments/$ENVIRONMENT/terraform.tfvars
-          worker_image         = "${{ secrets.WORKER_IMAGE }}"
-          user_image           = "${{ secrets.USER_IMAGE }}"
-          db_allowed_ip        = "${{ secrets.DB_ALLOWED_IP }}"
-          db_password          = "${{ secrets.DB_PASSWORD }}"
-          certificate_arn      = "${{ secrets.CERTIFICATE_ARN }}"
-          api_host             = "${{ secrets.API_HOST }}"
-          app_env              = "${{ secrets.APP_ENV }}"
-          coc_api_token        = "${{ secrets.COC_API_TOKEN }}"
-          google_client_id     = "${{ secrets.GOOGLE_CLIENT_ID }}"
-          google_client_secret = "${{ secrets.GOOGLE_CLIENT_SECRET }}"
-          backend_bucket       = "${{ secrets.BACKEND_BUCKET }}"
-          backend_dynamodb_table = "${{ secrets.BACKEND_DYNAMODB_TABLE }}"
-          frontend_bucket_name   = "${{ secrets.FRONT_END_BUCKET }}"
-          frontend_domain_names   = ["${{ secrets.FRONTEND_DOMAIN_NAMES }}"]
-          frontend_certificate_arn = "${{ secrets.CERTIFICATE_ARN }}"
-          messages_image = "${{ secrets.MESSAGES_IMAGE }}"
-          notifications_image = "${{ secrets.NOTIFICATIONS_IMAGE }}"
-          cors_allowed_origins = ["${{ secrets.CORS_ALLOWED_ORIGINS }}"]
-          vapid_secret_name = "${{ secrets.VAPID_SECRET_NAME }}"
-          cookie_domain = "${{ secrets.COOKIE_DOMAIN }}"
-          session_max_age = "${{ secrets.SESSION_MAX_AGE }}"
-          welcome_bucket_name = "${{ secrets.WELCOME_BUCKET_NAME }}"
-          welcome_domain_names = ["${{ secrets.WELCOME_DOMAIN_NAMES }}"]
-          welcome_certificate_arn = "${{ secrets.WELCOME_CERTIFICATE_ARN }}"
-          EOF
-        shell: bash
+      - name: Write tfvars from secret
+        run: printf '%s\n' "$TF_VARS" > environments/$ENVIRONMENT/terraform.tfvars
+        env:
+          TF_VARS: ${{ secrets.TFVARS }}
       - name: Initialize
         run: cd environments/$ENVIRONMENT && tofu init -input=false
       - name: Apply

--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ terraform apply
 ## Continuous Integration
 GitHub Actions validate the configuration on every pull request. Formatting and validation are run with OpenTofu.
 
-Pushing to `main` automatically applies the configuration for the `dev` environment. Tags matching `qa-*` or `prod-*` trigger deployments to `qa` and `prod`.
+Deployments read a single `TFVARS` secret from each GitHub environment. Pushing to `main` applies the `dev` environment while tags matching `qa-*` or `prod-*` apply `qa` and `prod`.
 


### PR DESCRIPTION
## Summary
- update deploy workflow to read all variables from `TFVARS` secret
- document new deployment secret

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_68894b03c3c0832ca9cdd1101b1014e8