### PR TITLE
Simplify deploy workflow with env secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: ${{ github.ref == 'refs/heads/main' && 'dev' || startsWith(github.ref, 'refs/tags/qa-') && 'qa' || 'prod' }}
     steps:
       - uses: actions/checkout@v3
       - uses: opentofu/setup-opentofu@v1
@@ -28,35 +29,11 @@ jobs:
           else
             echo "ENVIRONMENT=prod" >> $GITHUB_ENV
           fi
-      - name: Build tfvars from secrets
-        run: |
-          cat <<EOF > environments/$ENVIRONMENT/terraform.tfvars
-          worker_image         = "${{ secrets.WORKER_IMAGE }}"
-          user_image           = "${{ secrets.USER_IMAGE }}"
-          db_allowed_ip        = "${{ secrets.DB_ALLOWED_IP }}"
-          db_password          = "${{ secrets.DB_PASSWORD }}"
-          certificate_arn      = "${{ secrets.CERTIFICATE_ARN }}"
-          api_host             = "${{ secrets.API_HOST }}"
-          app_env              = "${{ secrets.APP_ENV }}"
-          coc_api_token        = "${{ secrets.COC_API_TOKEN }}"
-          google_client_id     = "${{ secrets.GOOGLE_CLIENT_ID }}"
-          google_client_secret = "${{ secrets.GOOGLE_CLIENT_SECRET }}"
-          backend_bucket       = "${{ secrets.BACKEND_BUCKET }}"
-          backend_dynamodb_table = "${{ secrets.BACKEND_DYNAMODB_TABLE }}"
-          frontend_bucket_name   = "${{ secrets.FRONT_END_BUCKET }}"
-          frontend_domain_names   = ["${{ secrets.FRONTEND_DOMAIN_NAMES }}"]
-          frontend_certificate_arn = "${{ secrets.CERTIFICATE_ARN }}"
-          messages_image = "${{ secrets.MESSAGES_IMAGE }}"
-          notifications_image = "${{ secrets.NOTIFICATIONS_IMAGE }}"
-          cors_allowed_origins = ["${{ secrets.CORS_ALLOWED_ORIGINS }}"]
-          vapid_secret_name = "${{ secrets.VAPID_SECRET_NAME }}"
-          cookie_domain = "${{ secrets.COOKIE_DOMAIN }}"
-          session_max_age = "${{ secrets.SESSION_MAX_AGE }}"
-          welcome_bucket_name = "${{ secrets.WELCOME_BUCKET_NAME }}"
-          welcome_domain_names = ["${{ secrets.WELCOME_DOMAIN_NAMES }}"]
-          welcome_certificate_arn = "${{ secrets.WELCOME_CERTIFICATE_ARN }}"
-          EOF
+      - name: Write tfvars from environment secret
+        run: echo "$TFVARS" > environments/$ENVIRONMENT/terraform.tfvars
         shell: bash
+        env:
+          TFVARS: ${{ secrets.TFVARS }}
       - name: Initialize
         run: cd environments/$ENVIRONMENT && tofu init -input=false
       - name: Apply

--- a/README.md
+++ b/README.md
@@ -85,5 +85,5 @@ terraform apply
 ## Continuous Integration
 GitHub Actions validate the configuration on every pull request. Formatting and validation are run with OpenTofu.
 
-Pushing to `main` automatically applies the configuration for the `dev` environment. Tags matching `qa-*` or `prod-*` trigger deployments to `qa` and `prod`.
+Deployments use GitHub environments. Pushing to `main` applies the configuration for the `dev` environment, while tags matching `qa-*` or `prod-*` trigger deployments to `qa` and `prod`. Each environment exposes a `TFVARS` secret whose contents are written to `terraform.tfvars` during the workflow.
 

--- a/modules/welcome/main.tf
+++ b/modules/welcome/main.tf
@@ -13,10 +13,10 @@ resource "aws_s3_bucket_public_access_block" "this" {
 data "aws_caller_identity" "current" {}
 
 resource "aws_cloudfront_origin_access_control" "this" {
-  name                            = "${var.bucket_name}-oac"
+  name                              = "${var.bucket_name}-oac"
   origin_access_control_origin_type = "s3"
-  signing_behavior                = "always"
-  signing_protocol                = "sigv4"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
 }
 
 resource "aws_cloudfront_distribution" "this" {
@@ -73,7 +73,7 @@ resource "aws_cloudfront_distribution" "this" {
 
 data "aws_iam_policy_document" "allow_cf" {
   statement {
-    actions   = ["s3:GetObject"]
+    actions = ["s3:GetObject"]
     principals {
       type        = "Service"
       identifiers = ["cloudfront.amazonaws.com"]


### PR DESCRIPTION
## Summary
- read tfvars from `TFVARS` secret
- use GitHub environments to pick the deployment stage
- document new pipeline behaviour
- format `welcome` module

## Testing
- `tofu fmt -check -recursive`
- `tofu validate`

------
https://chatgpt.com/codex/tasks/task_e_68894b03c3c0832ca9cdd1101b1014e8