### PR TITLE
Restrict lower envs with interface WAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This configuration provisions an AWS environment for a containerized web applica
   container images without internet access
 - `alb` provisions the Application Load Balancer and related security group
 - `waf` deploys an AWS WAFv2 Web ACL attached to the ALB
+- `waf` also creates an optional IP-restriction Web ACL for non-production
+  environments which is associated with both CloudFront distributions and the
+  ALB.
 - `rds` creates the Postgres database in the private subnets
 - `secrets` stores application configuration in Secrets Manager for the ECS tasks.
 - `ecs` sets up the ECS cluster, task definitions and services. The user service is registered in Cloud Map so other tasks can reach it via `user.<app_name>.local` and is exposed through the ALB at `/api/v1/friends`. It now requires the chat table ARN and related secret ARNs so tasks can read and write chat messages.
@@ -47,6 +50,8 @@ frontend_certificate_arn = "<acm cert arn for frontend>"
 welcome_bucket_name = "<s3 bucket for welcome page>"
 welcome_domain_names = ["welcome.example.com"]
 welcome_certificate_arn = "<acm cert arn for welcome>"
+interface_ipv4_cidrs   = ["203.0.113.0/24"]
+interface_ipv6_cidrs   = ["2001:db8::/48"]
 ```
 
 2. Create the state bucket and DynamoDB table using the helper script. The

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ frontend_certificate_arn = "<acm cert arn for frontend>"
 welcome_bucket_name = "<s3 bucket for welcome page>"
 welcome_domain_names = ["welcome.example.com"]
 welcome_certificate_arn = "<acm cert arn for welcome>"
-interface_ipv4_cidrs   = ["203.0.113.0/24"]
-interface_ipv6_cidrs   = ["2001:db8::/48"]
+# Optional: restrict access to the interface by IP
+interface_ipv4_cidrs   = []
+interface_ipv6_cidrs   = []
 ```
 
 2. Create the state bucket and DynamoDB table using the helper script. The

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -19,8 +19,10 @@ module "networking" {
 }
 
 module "waf" {
-  source   = "../../modules/waf"
-  app_name = var.app_name
+  source               = "../../modules/waf"
+  app_name             = var.app_name
+  interface_ipv4_cidrs = var.interface_ipv4_cidrs
+  interface_ipv6_cidrs = var.interface_ipv6_cidrs
 }
 
 module "alb" {
@@ -30,7 +32,7 @@ module "alb" {
   public_subnet_ids = module.networking.public_subnet_ids
   certificate_arn   = var.certificate_arn
   api_host          = var.api_host
-  waf_web_acl_arn   = module.waf.web_acl_arn
+  waf_web_acl_arn   = coalesce(module.waf.interface_regional_web_acl_arn, module.waf.web_acl_arn)
 }
 
 module "chat" {
@@ -130,6 +132,7 @@ module "frontend" {
   bucket_name     = var.frontend_bucket_name
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
+  web_acl_id      = module.waf.interface_cloudfront_web_acl_arn
 }
 
 module "welcome" {
@@ -137,4 +140,5 @@ module "welcome" {
   bucket_name     = var.welcome_bucket_name
   domain_names    = var.welcome_domain_names
   certificate_arn = var.welcome_certificate_arn
+  web_acl_id      = module.waf.interface_cloudfront_web_acl_arn
 }

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -156,3 +156,13 @@ variable "welcome_certificate_arn" {
   type        = string
   default     = null
 }
+
+variable "interface_ipv4_cidrs" {
+  description = "IPv4 CIDRs allowed to access the interface"
+  type        = list(string)
+}
+
+variable "interface_ipv6_cidrs" {
+  description = "IPv6 CIDRs allowed to access the interface"
+  type        = list(string)
+}

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -160,9 +160,11 @@ variable "welcome_certificate_arn" {
 variable "interface_ipv4_cidrs" {
   description = "IPv4 CIDRs allowed to access the interface"
   type        = list(string)
+  default     = []
 }
 
 variable "interface_ipv6_cidrs" {
   description = "IPv6 CIDRs allowed to access the interface"
   type        = list(string)
+  default     = []
 }

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -30,7 +30,7 @@ module "alb" {
   public_subnet_ids = module.networking.public_subnet_ids
   certificate_arn   = var.certificate_arn
   api_host          = var.api_host
-  waf_web_acl_arn   = module.waf.web_acl_arn
+  waf_web_acl_arn   = coalesce(module.waf.interface_regional_web_acl_arn, module.waf.web_acl_arn)
 }
 
 module "chat" {

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -156,3 +156,15 @@ variable "welcome_certificate_arn" {
   type        = string
   default     = null
 }
+
+variable "interface_ipv4_cidrs" {
+  description = "IPv4 CIDRs allowed to access the interface"
+  type        = list(string)
+  default     = []
+}
+
+variable "interface_ipv6_cidrs" {
+  description = "IPv6 CIDRs allowed to access the interface"
+  type        = list(string)
+  default     = []
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -19,8 +19,10 @@ module "networking" {
 }
 
 module "waf" {
-  source   = "../../modules/waf"
-  app_name = var.app_name
+  source               = "../../modules/waf"
+  app_name             = var.app_name
+  interface_ipv4_cidrs = var.interface_ipv4_cidrs
+  interface_ipv6_cidrs = var.interface_ipv6_cidrs
 }
 
 module "alb" {
@@ -30,7 +32,7 @@ module "alb" {
   public_subnet_ids = module.networking.public_subnet_ids
   certificate_arn   = var.certificate_arn
   api_host          = var.api_host
-  waf_web_acl_arn   = module.waf.web_acl_arn
+  waf_web_acl_arn   = coalesce(module.waf.interface_regional_web_acl_arn, module.waf.web_acl_arn)
 }
 
 module "chat" {
@@ -130,6 +132,7 @@ module "frontend" {
   bucket_name     = var.frontend_bucket_name
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
+  web_acl_id      = module.waf.interface_cloudfront_web_acl_arn
 }
 
 module "welcome" {
@@ -137,4 +140,5 @@ module "welcome" {
   bucket_name     = var.welcome_bucket_name
   domain_names    = var.welcome_domain_names
   certificate_arn = var.welcome_certificate_arn
+  web_acl_id      = module.waf.interface_cloudfront_web_acl_arn
 }

--- a/environments/qa/variables.tf
+++ b/environments/qa/variables.tf
@@ -156,3 +156,13 @@ variable "welcome_certificate_arn" {
   type        = string
   default     = null
 }
+
+variable "interface_ipv4_cidrs" {
+  description = "IPv4 CIDRs allowed to access the interface"
+  type        = list(string)
+}
+
+variable "interface_ipv6_cidrs" {
+  description = "IPv6 CIDRs allowed to access the interface"
+  type        = list(string)
+}

--- a/environments/qa/variables.tf
+++ b/environments/qa/variables.tf
@@ -160,9 +160,11 @@ variable "welcome_certificate_arn" {
 variable "interface_ipv4_cidrs" {
   description = "IPv4 CIDRs allowed to access the interface"
   type        = list(string)
+  default     = []
 }
 
 variable "interface_ipv6_cidrs" {
   description = "IPv6 CIDRs allowed to access the interface"
   type        = list(string)
+  default     = []
 }

--- a/modules/frontend/main.tf
+++ b/modules/frontend/main.tf
@@ -41,6 +41,7 @@ resource "aws_s3_bucket_policy" "public" {
 resource "aws_cloudfront_distribution" "this" {
   enabled             = true
   default_root_object = "index.html"
+  web_acl_id          = var.web_acl_id
 
   origin {
     domain_name = aws_s3_bucket.this.bucket_regional_domain_name

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -9,3 +9,8 @@ variable "certificate_arn" {
   type    = string
   default = null
 }
+
+variable "web_acl_id" {
+  type    = string
+  default = null
+}

--- a/modules/waf/main.tf
+++ b/modules/waf/main.tf
@@ -126,35 +126,47 @@ resource "aws_wafv2_web_acl" "interface_regional" {
     block {}
   }
 
-  rule {
-    name     = "allow-interface"
-    priority = 0
+  dynamic "rule" {
+    for_each = aws_wafv2_ip_set.interface_v4_regional
+    content {
+      name     = "allow-interface-v4"
+      priority = 0
 
-    action {
-      allow {}
-    }
+      action {
+        allow {}
+      }
 
-    statement {
-      or_statement {
-        dynamic "statement" {
-          for_each = aws_wafv2_ip_set.interface_v4_regional
-          content {
-            ip_set_reference_statement { arn = statement.value.arn }
-          }
-        }
-        dynamic "statement" {
-          for_each = aws_wafv2_ip_set.interface_v6_regional
-          content {
-            ip_set_reference_statement { arn = statement.value.arn }
-          }
-        }
+      statement {
+        ip_set_reference_statement { arn = rule.value.arn }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "allow-interface-v4"
+        sampled_requests_enabled   = true
       }
     }
+  }
 
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "allow-interface"
-      sampled_requests_enabled   = true
+  dynamic "rule" {
+    for_each = aws_wafv2_ip_set.interface_v6_regional
+    content {
+      name     = "allow-interface-v6"
+      priority = length(aws_wafv2_ip_set.interface_v4_regional) > 0 ? 1 : 0
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement { arn = rule.value.arn }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "allow-interface-v6"
+        sampled_requests_enabled   = true
+      }
     }
   }
 
@@ -174,35 +186,47 @@ resource "aws_wafv2_web_acl" "interface_cf" {
     block {}
   }
 
-  rule {
-    name     = "allow-interface"
-    priority = 0
+  dynamic "rule" {
+    for_each = aws_wafv2_ip_set.interface_v4_cf
+    content {
+      name     = "allow-interface-v4"
+      priority = 0
 
-    action {
-      allow {}
-    }
+      action {
+        allow {}
+      }
 
-    statement {
-      or_statement {
-        dynamic "statement" {
-          for_each = aws_wafv2_ip_set.interface_v4_cf
-          content {
-            ip_set_reference_statement { arn = statement.value.arn }
-          }
-        }
-        dynamic "statement" {
-          for_each = aws_wafv2_ip_set.interface_v6_cf
-          content {
-            ip_set_reference_statement { arn = statement.value.arn }
-          }
-        }
+      statement {
+        ip_set_reference_statement { arn = rule.value.arn }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "allow-interface-v4"
+        sampled_requests_enabled   = true
       }
     }
+  }
 
-    visibility_config {
-      cloudwatch_metrics_enabled = true
-      metric_name                = "allow-interface"
-      sampled_requests_enabled   = true
+  dynamic "rule" {
+    for_each = aws_wafv2_ip_set.interface_v6_cf
+    content {
+      name     = "allow-interface-v6"
+      priority = length(aws_wafv2_ip_set.interface_v4_cf) > 0 ? 1 : 0
+
+      action {
+        allow {}
+      }
+
+      statement {
+        ip_set_reference_statement { arn = rule.value.arn }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "allow-interface-v6"
+        sampled_requests_enabled   = true
+      }
     }
   }
 

--- a/modules/waf/outputs.tf
+++ b/modules/waf/outputs.tf
@@ -1,3 +1,11 @@
 output "web_acl_arn" {
   value = aws_wafv2_web_acl.this.arn
 }
+
+output "interface_regional_web_acl_arn" {
+  value = length(aws_wafv2_web_acl.interface_regional) > 0 ? aws_wafv2_web_acl.interface_regional[0].arn : null
+}
+
+output "interface_cloudfront_web_acl_arn" {
+  value = length(aws_wafv2_web_acl.interface_cf) > 0 ? aws_wafv2_web_acl.interface_cf[0].arn : null
+}

--- a/modules/waf/variables.tf
+++ b/modules/waf/variables.tf
@@ -1,1 +1,11 @@
 variable "app_name" { type = string }
+
+variable "interface_ipv4_cidrs" {
+  type    = list(string)
+  default = []
+}
+
+variable "interface_ipv6_cidrs" {
+  type    = list(string)
+  default = []
+}

--- a/modules/welcome/main.tf
+++ b/modules/welcome/main.tf
@@ -22,6 +22,7 @@ resource "aws_cloudfront_origin_access_control" "this" {
 resource "aws_cloudfront_distribution" "this" {
   enabled             = true
   default_root_object = "index.html"
+  web_acl_id          = var.web_acl_id
 
   origin {
     domain_name              = aws_s3_bucket.this.bucket_regional_domain_name

--- a/modules/welcome/variables.tf
+++ b/modules/welcome/variables.tf
@@ -9,3 +9,8 @@ variable "certificate_arn" {
   type    = string
   default = null
 }
+
+variable "web_acl_id" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
## Summary
- extend WAF module with optional IP set and Web ACL for IPv4/IPv6
- expose interface ACL ARNs
- associate new ACL with ALB and CloudFront in dev and qa
- allow configuration via `interface_ipv4_cidrs` and `interface_ipv6_cidrs`
- document new variables

## Testing
- `tofu fmt -recursive`
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_6889762cffb8832c8658bf1218f95c09