### PR TITLE
Add Redis cache integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This configuration provisions an AWS environment for a containerized web applica
   environments which is associated with both CloudFront distributions and the
   ALB.
 - `rds` creates the Postgres database in the private subnets
+- `redis` provisions an ElastiCache cluster and stores its connection URL in Secrets Manager
 - `secrets` stores application configuration in Secrets Manager for the ECS tasks.
 - `ecs` sets up the ECS cluster, task definitions and services. The user service is registered in Cloud Map so other tasks can reach it via `user.<app_name>.local` and is exposed through the ALB at `/api/v1/friends`. It now requires the chat table ARN and related secret ARNs so tasks can read and write chat messages.
   The user task also receives database credentials from Secrets Manager.

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -65,6 +65,14 @@ module "notifications" {
   chat_table_stream_arn = module.chat.chat_table_stream_arn
 }
 
+module "redis" {
+  source     = "../../modules/redis"
+  app_name   = var.app_name
+  vpc_id     = module.networking.vpc_id
+  subnet_ids = module.networking.private_subnet_ids
+  vpc_cidr   = module.networking.vpc_cidr
+}
+
 module "ecs" {
   source                             = "../../modules/ecs"
   app_name                           = var.app_name
@@ -94,6 +102,7 @@ module "ecs" {
   session_max_age_arn                = module.secrets.session_max_age_arn
   cookie_domain_arn                  = module.secrets.cookie_domain_arn
   cookie_secure_arn                  = module.secrets.cookie_secure_arn
+  redis_url_arn                      = module.redis.redis_url_arn
   messages_allowed_origins_arn       = module.secrets.messages_allowed_origins_arn
   user_allowed_origins_arn           = module.secrets.user_allowed_origins_arn
   notifications_allowed_origins_arn  = module.secrets.notifications_allowed_origins_arn

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -63,6 +63,14 @@ module "notifications" {
   chat_table_stream_arn = module.chat.chat_table_stream_arn
 }
 
+module "redis" {
+  source     = "../../modules/redis"
+  app_name   = var.app_name
+  vpc_id     = module.networking.vpc_id
+  subnet_ids = module.networking.private_subnet_ids
+  vpc_cidr   = module.networking.vpc_cidr
+}
+
 module "ecs" {
   source                             = "../../modules/ecs"
   app_name                           = var.app_name
@@ -92,6 +100,7 @@ module "ecs" {
   session_max_age_arn                = module.secrets.session_max_age_arn
   cookie_domain_arn                  = module.secrets.cookie_domain_arn
   cookie_secure_arn                  = module.secrets.cookie_secure_arn
+  redis_url_arn                      = module.redis.redis_url_arn
   messages_allowed_origins_arn       = module.secrets.messages_allowed_origins_arn
   user_allowed_origins_arn           = module.secrets.user_allowed_origins_arn
   notifications_allowed_origins_arn  = module.secrets.notifications_allowed_origins_arn

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -65,6 +65,14 @@ module "notifications" {
   chat_table_stream_arn = module.chat.chat_table_stream_arn
 }
 
+module "redis" {
+  source     = "../../modules/redis"
+  app_name   = var.app_name
+  vpc_id     = module.networking.vpc_id
+  subnet_ids = module.networking.private_subnet_ids
+  vpc_cidr   = module.networking.vpc_cidr
+}
+
 module "ecs" {
   source                             = "../../modules/ecs"
   app_name                           = var.app_name
@@ -94,6 +102,7 @@ module "ecs" {
   session_max_age_arn                = module.secrets.session_max_age_arn
   cookie_domain_arn                  = module.secrets.cookie_domain_arn
   cookie_secure_arn                  = module.secrets.cookie_secure_arn
+  redis_url_arn                      = module.redis.redis_url_arn
   messages_allowed_origins_arn       = module.secrets.messages_allowed_origins_arn
   user_allowed_origins_arn           = module.secrets.user_allowed_origins_arn
   notifications_allowed_origins_arn  = module.secrets.notifications_allowed_origins_arn

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -230,6 +230,7 @@ resource "aws_iam_role_policy" "execution_secrets" {
         var.session_max_age_arn,
         var.cookie_domain_arn,
         var.cookie_secure_arn,
+        var.redis_url_arn,
         "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO"
       ]
     }]
@@ -349,6 +350,10 @@ resource "aws_ecs_task_definition" "worker" {
           valueFrom = var.messages_allowed_origins_arn
         },
         {
+          name      = "REDIS_URL"
+          valueFrom = var.redis_url_arn
+        },
+        {
           name      = "COC_EMAIL"
           valueFrom = "arn:aws:secretsmanager:us-east-1:660170479310:secret:all-env/coc-api-access-1sBKxO:COC_EMAIL::"
         },
@@ -457,6 +462,10 @@ resource "aws_ecs_task_definition" "user" {
         {
           name      = "COOKIE_SECURE"
           valueFrom = var.cookie_secure_arn
+        },
+        {
+          name      = "REDIS_URL"
+          valueFrom = var.redis_url_arn
         }
       ]
     }
@@ -550,6 +559,10 @@ resource "aws_ecs_task_definition" "messages" {
         {
           name      = "COOKIE_SECURE"
           valueFrom = var.cookie_secure_arn
+        },
+        {
+          name      = "REDIS_URL"
+          valueFrom = var.redis_url_arn
         }
       ]
     }
@@ -651,6 +664,10 @@ resource "aws_ecs_task_definition" "notifications" {
         {
           name      = "COOKIE_SECURE"
           valueFrom = var.cookie_secure_arn
+        },
+        {
+          name      = "REDIS_URL"
+          valueFrom = var.redis_url_arn
         }
       ]
     }

--- a/modules/ecs/variables.tf
+++ b/modules/ecs/variables.tf
@@ -40,3 +40,4 @@ variable "jwt_signing_key_arn" { type = string }
 variable "session_max_age_arn" { type = string }
 variable "cookie_domain_arn" { type = string }
 variable "cookie_secure_arn" { type = string }
+variable "redis_url_arn" { type = string }

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -1,0 +1,44 @@
+resource "aws_security_group" "redis" {
+  name        = "${var.app_name}-redis-sg"
+  description = "Allow Redis access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = 6379
+    to_port     = 6379
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_elasticache_subnet_group" "this" {
+  name       = "${var.app_name}-redis-subnet"
+  subnet_ids = var.subnet_ids
+}
+
+resource "aws_elasticache_cluster" "this" {
+  cluster_id           = "${var.app_name}-redis"
+  engine               = "redis"
+  node_type            = "cache.t3.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis7"
+  port                 = 6379
+  subnet_group_name    = aws_elasticache_subnet_group.this.name
+  security_group_ids   = [aws_security_group.redis.id]
+}
+
+resource "aws_secretsmanager_secret" "redis_url" {
+  name = "${var.app_name}-redis-url"
+}
+
+resource "aws_secretsmanager_secret_version" "redis_url" {
+  secret_id     = aws_secretsmanager_secret.redis_url.id
+  secret_string = "redis://${aws_elasticache_cluster.this.cache_nodes[0].address}:6379"
+}

--- a/modules/redis/outputs.tf
+++ b/modules/redis/outputs.tf
@@ -1,0 +1,7 @@
+output "redis_endpoint" {
+  value = aws_elasticache_cluster.this.cache_nodes[0].address
+}
+
+output "redis_url_arn" {
+  value = aws_secretsmanager_secret.redis_url.arn
+}

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,0 +1,4 @@
+variable "app_name" { type = string }
+variable "vpc_id" { type = string }
+variable "subnet_ids" { type = list(string) }
+variable "vpc_cidr" { type = string }


### PR DESCRIPTION
## Summary
- add new Redis module deploying an ElastiCache cluster
- inject Redis connection secret into all ECS task definitions
- wire new module into each environment
- document the Redis module in the README

## Testing
- `tofu fmt -check -recursive`
- `tofu validate`

------
https://chatgpt.com/codex/tasks/task_e_6889b1290600832c9594c3a678bcbb7d