### PR TITLE
Allow messages service to access Postgres

### DIFF
--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -530,6 +530,14 @@ resource "aws_ecs_task_definition" "messages" {
           valueFrom = var.database_url_arn
         },
         {
+          name      = "DATABASE_USERNAME"
+          valueFrom = var.database_username_arn
+        },
+        {
+          name      = "DATABASE_PASSWORD"
+          valueFrom = var.database_password_arn
+        },
+        {
           name      = "SECRET_KEY"
           valueFrom = var.secret_key_arn
         },


### PR DESCRIPTION
## Summary
- add DATABASE_USERNAME and DATABASE_PASSWORD secrets to the messages task definition

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_688a4bb4f6ac832ca84937a90b3a50bc