### PR TITLE
Update lambda runtime to Node.js 20

### DIFF
--- a/modules/notifications/main.tf
+++ b/modules/notifications/main.tf
@@ -10,7 +10,7 @@ data "archive_file" "lambda" {
 
 resource "aws_lambda_function" "stream" {
   function_name    = "${var.app_name}-chat-stream"
-  runtime          = "nodejs18.x"
+  runtime          = "nodejs20.x"
   handler          = "index.handler"
   role             = aws_iam_role.lambda.arn
   filename         = data.archive_file.lambda.output_path


### PR DESCRIPTION
## Summary
- upgrade the notifications lambda runtime from Node.js 18 to Node.js 20

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_688cee212270832ca926e6cc5599ec0f