### PR TITLE
Add ECR cleanup Lambda module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This configuration provisions an AWS environment for a containerized web applica
 - `frontend` creates an S3 bucket configured for static website hosting and a CloudFront distribution that forwards the `If-None-Match` header so the web app can be served directly from S3.
 - `welcome` creates a private S3 bucket with a CloudFront distribution using origin access control.
 - `chat` provisions a DynamoDB table used for the chat service with streams enabled. The table name, ARN and stream ARN are exported for other modules.
+- `ecr_cleanup` deploys a Lambda that runs weekly to remove old ECR images, keeping the 11 most recently pushed.
 
 Each container logs to its own CloudWatch log group and the worker receives its environment via Secrets Manager along with Google OAuth credentials. The worker also loads `COC_EMAIL` and `COC_PASSWORD` from a shared secret. The worker talks to the user service at `user.<app_name>.local` or through the ALB path `/api/v1/friends`. The messages task now loads `OPENAI_API_KEY` from the `{env}/openai/moderation` secret and `PERSPECTIVE_API_KEY` from the `{env}/perspective/moderation` secret.
 ## Usage

--- a/environments/dev/main.tf
+++ b/environments/dev/main.tf
@@ -161,3 +161,8 @@ module "welcome" {
   certificate_arn = var.welcome_certificate_arn
   web_acl_id      = module.waf.interface_cloudfront_web_acl_arn
 }
+
+module "ecr_cleanup" {
+  source   = "../../modules/ecr_cleanup"
+  app_name = var.app_name
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -157,3 +157,8 @@ module "welcome" {
   domain_names    = var.welcome_domain_names
   certificate_arn = var.welcome_certificate_arn
 }
+
+module "ecr_cleanup" {
+  source   = "../../modules/ecr_cleanup"
+  app_name = var.app_name
+}

--- a/environments/qa/main.tf
+++ b/environments/qa/main.tf
@@ -161,3 +161,8 @@ module "welcome" {
   certificate_arn = var.welcome_certificate_arn
   web_acl_id      = module.waf.interface_cloudfront_web_acl_arn
 }
+
+module "ecr_cleanup" {
+  source   = "../../modules/ecr_cleanup"
+  app_name = var.app_name
+}

--- a/modules/ecr_cleanup/cleanup.py
+++ b/modules/ecr_cleanup/cleanup.py
@@ -1,0 +1,25 @@
+import boto3
+from datetime import datetime, timezone
+
+ECR = boto3.client("ecr")
+KEEP = 11
+
+def lambda_handler(event, context):
+  repos = []
+  paginator = ECR.get_paginator("describe_repositories")
+  for page in paginator.paginate():
+    repos.extend([r["repositoryName"] for r in page.get("repositories", [])])
+
+  for repo in repos:
+    images = []
+    paginator = ECR.get_paginator("describe_images")
+    for page in paginator.paginate(repositoryName=repo):
+      images.extend(page.get("imageDetails", []))
+
+    images.sort(key=lambda x: x.get("imagePushedAt", datetime(1970, 1, 1, tzinfo=timezone.utc)), reverse=True)
+    old_images = images[KEEP:]
+    image_ids = [{"imageDigest": img["imageDigest"]} for img in old_images if "imageDigest" in img]
+    if image_ids:
+      ECR.batch_delete_image(repositoryName=repo, imageIds=image_ids)
+
+  return {"status": "ok"}

--- a/modules/ecr_cleanup/main.tf
+++ b/modules/ecr_cleanup/main.tf
@@ -1,0 +1,77 @@
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_file = "${path.module}/cleanup.py"
+  output_path = "${path.module}/cleanup.zip"
+}
+
+resource "aws_iam_role" "this" {
+  name = "${var.app_name}-ecr-cleanup-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "this" {
+  name = "${var.app_name}-ecr-cleanup-policy"
+  role = aws_iam_role.this.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:DescribeRepositories",
+          "ecr:ListImages",
+          "ecr:DescribeImages",
+          "ecr:BatchDeleteImage"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_lambda_function" "this" {
+  function_name    = "${var.app_name}-ecr-cleanup"
+  filename         = data.archive_file.lambda.output_path
+  source_code_hash = data.archive_file.lambda.output_base64sha256
+  role             = aws_iam_role.this.arn
+  handler          = "cleanup.lambda_handler"
+  runtime          = "python3.11"
+  timeout          = 300
+}
+
+resource "aws_cloudwatch_event_rule" "weekly" {
+  name                = "${var.app_name}-ecr-cleanup-weekly"
+  schedule_expression = "rate(7 days)"
+}
+
+resource "aws_cloudwatch_event_target" "weekly" {
+  rule      = aws_cloudwatch_event_rule.weekly.name
+  target_id = "ecr-cleanup"
+  arn       = aws_lambda_function.this.arn
+}
+
+resource "aws_lambda_permission" "allow_events" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.weekly.arn
+}

--- a/modules/ecr_cleanup/outputs.tf
+++ b/modules/ecr_cleanup/outputs.tf
@@ -1,0 +1,4 @@
+output "lambda_function_name" {
+  description = "Name of the cleanup Lambda function"
+  value       = aws_lambda_function.this.function_name
+}

--- a/modules/ecr_cleanup/variables.tf
+++ b/modules/ecr_cleanup/variables.tf
@@ -1,0 +1,4 @@
+variable "app_name" {
+  description = "Application name for resource naming"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add ECR cleanup module with Lambda and weekly schedule
- remove older images beyond 11 most recent in all ECR repositories
- wire cleanup module into all environments

## Testing
- `tofu fmt -recursive`
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate`


------
https://chatgpt.com/codex/tasks/task_e_688eaf57fcb0832c921533732edf29b0