### PR TITLE
Batch delete ECR images in chunks

### DIFF
--- a/modules/ecr_cleanup/cleanup.py
+++ b/modules/ecr_cleanup/cleanup.py
@@ -19,7 +19,9 @@ def lambda_handler(event, context):
     images.sort(key=lambda x: x.get("imagePushedAt", datetime(1970, 1, 1, tzinfo=timezone.utc)), reverse=True)
     old_images = images[KEEP:]
     image_ids = [{"imageDigest": img["imageDigest"]} for img in old_images if "imageDigest" in img]
-    if image_ids:
-      ECR.batch_delete_image(repositoryName=repo, imageIds=image_ids)
+    for i in range(0, len(image_ids), 100):
+      batch = image_ids[i : i + 100]
+      if batch:
+        ECR.batch_delete_image(repositoryName=repo, imageIds=batch)
 
   return {"status": "ok"}


### PR DESCRIPTION
## Summary
- handle ECR cleanup deletions in batches to respect AWS API limits

## Testing
- `tofu init -backend=false`
- `tofu fmt -check -recursive`
- `tofu validate` *(fails: missing provider plugins registry.opentofu.org/hashicorp/aws 5.100.0 and registry.opentofu.org/hashicorp/random 3.7.2)*

------
https://chatgpt.com/codex/tasks/task_e_688eb3a2fac4832c9b1eff1d0b4b3be1