### PR TITLE
feat: Add refresh worker Lambda with CoC credentials support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ terraform.rc
 .DS_Store
 
 *.pem
+
+scripts/.env_state/*

--- a/environments/dev/variables.tf
+++ b/environments/dev/variables.tf
@@ -173,3 +173,20 @@ variable "interface_ipv6_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "coc_email" {
+  description = "Clash of Clans developer portal email"
+  type        = string
+  sensitive   = true
+}
+
+variable "coc_password" {
+  description = "Clash of Clans developer portal password"
+  type        = string
+  sensitive   = true
+}
+
+variable "lambda_artifacts_bucket" {
+  description = "S3 bucket for Lambda deployment artifacts"
+  type        = string
+}

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -12,6 +12,8 @@ provider "aws" {
   region = var.region
 }
 
+data "aws_caller_identity" "current" {}
+
 module "networking" {
   source   = "../../modules/networking"
   region   = var.region
@@ -19,8 +21,10 @@ module "networking" {
 }
 
 module "waf" {
-  source   = "../../modules/waf"
-  app_name = var.app_name
+  source               = "../../modules/waf"
+  app_name             = var.app_name
+  interface_ipv4_cidrs = var.interface_ipv4_cidrs
+  interface_ipv6_cidrs = var.interface_ipv6_cidrs
 }
 
 module "alb" {
@@ -46,6 +50,8 @@ module "secrets" {
   db_endpoint          = module.rds.db_endpoint
   db_username          = var.db_username
   db_password          = var.db_password
+  coc_email            = var.coc_email
+  coc_password         = var.coc_password
   chat_table           = module.chat.chat_table_name
   coc_api_token        = var.coc_api_token
   google_client_id     = var.google_client_id
@@ -151,6 +157,7 @@ module "frontend" {
   bucket_name     = var.frontend_bucket_name
   domain_names    = var.frontend_domain_names
   certificate_arn = var.frontend_certificate_arn
+  web_acl_id      = null
 }
 
 module "welcome" {
@@ -158,9 +165,29 @@ module "welcome" {
   bucket_name     = var.welcome_bucket_name
   domain_names    = var.welcome_domain_names
   certificate_arn = var.welcome_certificate_arn
+  web_acl_id      = null
 }
 
 module "ecr_cleanup" {
   source   = "../../modules/ecr_cleanup"
   app_name = var.app_name
+}
+
+module "lambda_artifacts" {
+  source      = "../../modules/lambda-artifacts"
+  bucket_name = var.lambda_artifacts_bucket
+}
+
+module "refresh_worker" {
+  source                  = "../../modules/refresh-worker"
+  app_name                = var.app_name
+  app_env                 = var.app_env
+  lambda_artifacts_bucket = module.lambda_artifacts.bucket_name
+  database_url_arn        = module.secrets.database_url_arn
+  redis_url_arn           = module.redis.redis_url_arn
+  coc_email_arn           = module.secrets.coc_email_arn
+  coc_password_arn        = module.secrets.coc_password_arn
+  vpc_id                  = module.networking.vpc_id
+  lambda_subnet_ids       = module.networking.private_subnet_ids
+  depends_on              = [module.lambda_artifacts]
 }

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -173,3 +173,20 @@ variable "interface_ipv6_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "coc_email" {
+  description = "Clash of Clans developer portal email"
+  type        = string
+  sensitive   = true
+}
+
+variable "coc_password" {
+  description = "Clash of Clans developer portal password"
+  type        = string
+  sensitive   = true
+}
+
+variable "lambda_artifacts_bucket" {
+  description = "S3 bucket for Lambda deployment artifacts"
+  type        = string
+}

--- a/environments/qa/variables.tf
+++ b/environments/qa/variables.tf
@@ -173,3 +173,20 @@ variable "interface_ipv6_cidrs" {
   type        = list(string)
   default     = []
 }
+
+variable "coc_email" {
+  description = "Clash of Clans developer portal email"
+  type        = string
+  sensitive   = true
+}
+
+variable "coc_password" {
+  description = "Clash of Clans developer portal password"
+  type        = string
+  sensitive   = true
+}
+
+variable "lambda_artifacts_bucket" {
+  description = "S3 bucket for Lambda deployment artifacts"
+  type        = string
+}

--- a/modules/lambda-artifacts/main.tf
+++ b/modules/lambda-artifacts/main.tf
@@ -1,0 +1,29 @@
+resource "aws_s3_bucket" "lambda_artifacts" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}

--- a/modules/lambda-artifacts/outputs.tf
+++ b/modules/lambda-artifacts/outputs.tf
@@ -1,0 +1,9 @@
+output "bucket_name" {
+  description = "Name of the lambda artifacts S3 bucket"
+  value       = aws_s3_bucket.lambda_artifacts.bucket
+}
+
+output "bucket_arn" {
+  description = "ARN of the lambda artifacts S3 bucket"
+  value       = aws_s3_bucket.lambda_artifacts.arn
+}

--- a/modules/lambda-artifacts/variables.tf
+++ b/modules/lambda-artifacts/variables.tf
@@ -1,0 +1,4 @@
+variable "bucket_name" {
+  description = "Name of the S3 bucket for Lambda deployment artifacts"
+  type        = string
+}

--- a/modules/refresh-worker/cloudwatch.tf
+++ b/modules/refresh-worker/cloudwatch.tf
@@ -1,0 +1,72 @@
+resource "aws_cloudwatch_event_rule" "refresh_schedule" {
+  name                = "${var.app_name}-refresh-worker-schedule"
+  description         = "Triggers the refresh worker Lambda every 2 minutes"
+  schedule_expression = var.schedule_expression
+}
+
+resource "aws_cloudwatch_event_target" "refresh_schedule" {
+  rule      = aws_cloudwatch_event_rule.refresh_schedule.name
+  target_id = "refresh-worker-target"
+  arn       = aws_lambda_function.this.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.this.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.refresh_schedule.arn
+}
+
+# CloudWatch Alarms for monitoring
+resource "aws_cloudwatch_metric_alarm" "error_rate" {
+  alarm_name          = "${var.app_name}-refresh-worker-error-rate"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "Errors"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "5"
+  alarm_description   = "Lambda function error rate is too high"
+  alarm_actions       = []
+
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "duration" {
+  alarm_name          = "${var.app_name}-refresh-worker-duration"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "Duration"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Average"
+  threshold           = "240000"
+  alarm_description   = "Lambda function duration approaching timeout"
+  alarm_actions       = []
+
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "no_invocations" {
+  alarm_name          = "${var.app_name}-refresh-worker-no-invocations"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "Invocations"
+  namespace           = "AWS/Lambda"
+  period              = "300"
+  statistic           = "Sum"
+  threshold           = "1"
+  alarm_description   = "Lambda function has not been invoked recently"
+  alarm_actions       = []
+  treat_missing_data  = "breaching"
+
+  dimensions = {
+    FunctionName = aws_lambda_function.this.function_name
+  }
+}

--- a/modules/refresh-worker/main.tf
+++ b/modules/refresh-worker/main.tf
@@ -1,0 +1,106 @@
+resource "aws_iam_role" "this" {
+  name = "${var.app_name}-refresh-worker-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "this" {
+  name = "${var.app_name}-refresh-worker-policy"
+  role = aws_iam_role.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          var.database_url_arn,
+          var.redis_url_arn,
+          var.coc_email_arn,
+          var.coc_password_arn
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "vpc_access" {
+  count      = var.vpc_config_enabled ? 1 : 0
+  role       = aws_iam_role.this.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+resource "aws_security_group" "this" {
+  count  = var.vpc_config_enabled ? 1 : 0
+  name   = "${var.app_name}-refresh-worker-sg"
+  vpc_id = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lambda_function" "this" {
+  function_name = "${var.app_name}-refresh-worker"
+  s3_bucket     = var.lambda_artifacts_bucket
+  s3_key        = var.lambda_s3_key
+  role          = aws_iam_role.this.arn
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.11"
+  timeout       = 300
+  memory_size   = 512
+
+  environment {
+    variables = {
+      DATABASE_URL_SECRET = replace(var.database_url_arn, "arn:aws:secretsmanager:", "")
+      REDIS_URL_SECRET    = replace(var.redis_url_arn, "arn:aws:secretsmanager:", "")
+      COC_EMAIL_SECRET    = replace(var.coc_email_arn, "arn:aws:secretsmanager:", "")
+      COC_PASSWORD_SECRET = replace(var.coc_password_arn, "arn:aws:secretsmanager:", "")
+      ENVIRONMENT         = var.app_env
+      LOG_LEVEL           = "INFO"
+      PYTHONPATH          = "/var/task:/opt/python"
+    }
+  }
+
+  dynamic "vpc_config" {
+    for_each = var.vpc_config_enabled ? [1] : []
+    content {
+      subnet_ids         = var.lambda_subnet_ids
+      security_group_ids = [aws_security_group.this[0].id]
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy.this,
+    aws_cloudwatch_log_group.this,
+  ]
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/aws/lambda/${var.app_name}-refresh-worker"
+  retention_in_days = var.log_retention_days
+}

--- a/modules/refresh-worker/outputs.tf
+++ b/modules/refresh-worker/outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_function_name" {
+  description = "Name of the refresh worker Lambda function"
+  value       = aws_lambda_function.this.function_name
+}
+
+output "lambda_function_arn" {
+  description = "ARN of the refresh worker Lambda function"
+  value       = aws_lambda_function.this.arn
+}
+
+output "lambda_role_arn" {
+  description = "ARN of the Lambda execution role"
+  value       = aws_iam_role.this.arn
+}
+
+output "lambda_log_group_name" {
+  description = "Name of the CloudWatch Log Group"
+  value       = aws_cloudwatch_log_group.this.name
+}

--- a/modules/refresh-worker/variables.tf
+++ b/modules/refresh-worker/variables.tf
@@ -1,0 +1,70 @@
+variable "app_name" {
+  description = "Application name for resource naming"
+  type        = string
+}
+
+variable "app_env" {
+  description = "Application environment (dev, qa, prod)"
+  type        = string
+}
+
+variable "lambda_artifacts_bucket" {
+  description = "S3 bucket containing Lambda deployment artifacts"
+  type        = string
+}
+
+variable "lambda_s3_key" {
+  description = "S3 key for the refresh worker lambda zip file"
+  type        = string
+  default     = "coc-refresh-worker-lambda.zip"
+}
+
+variable "database_url_arn" {
+  description = "ARN of the database URL secret in Secrets Manager"
+  type        = string
+}
+
+variable "redis_url_arn" {
+  description = "ARN of the Redis URL secret in Secrets Manager"
+  type        = string
+}
+
+variable "coc_email_arn" {
+  description = "ARN of the CoC email secret in Secrets Manager"
+  type        = string
+}
+
+variable "coc_password_arn" {
+  description = "ARN of the CoC password secret in Secrets Manager"
+  type        = string
+}
+
+variable "vpc_config_enabled" {
+  description = "Enable VPC configuration for Lambda (required for RDS/Redis access)"
+  type        = bool
+  default     = true
+}
+
+variable "vpc_id" {
+  description = "VPC ID for Lambda security group"
+  type        = string
+  default     = ""
+}
+
+variable "lambda_subnet_ids" {
+  description = "List of subnet IDs for Lambda VPC configuration"
+  type        = list(string)
+  default     = []
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days"
+  type        = number
+  default     = 14
+}
+
+variable "schedule_expression" {
+  description = "CloudWatch Events schedule expression"
+  type        = string
+  default     = "rate(2 minutes)"
+}

--- a/modules/secrets/main.tf
+++ b/modules/secrets/main.tf
@@ -160,3 +160,21 @@ resource "aws_secretsmanager_secret_version" "cookie_secure" {
   secret_id     = aws_secretsmanager_secret.cookie_secure.id
   secret_string = tostring(var.cookie_secure)
 }
+
+resource "aws_secretsmanager_secret" "coc_email" {
+  name = "${var.app_name}-coc-email"
+}
+
+resource "aws_secretsmanager_secret_version" "coc_email" {
+  secret_id     = aws_secretsmanager_secret.coc_email.id
+  secret_string = var.coc_email
+}
+
+resource "aws_secretsmanager_secret" "coc_password" {
+  name = "${var.app_name}-coc-password"
+}
+
+resource "aws_secretsmanager_secret_version" "coc_password" {
+  secret_id     = aws_secretsmanager_secret.coc_password.id
+  secret_string = var.coc_password
+}

--- a/modules/secrets/outputs.tf
+++ b/modules/secrets/outputs.tf
@@ -77,3 +77,11 @@ output "cookie_domain_arn" {
 output "cookie_secure_arn" {
   value = aws_secretsmanager_secret.cookie_secure.arn
 }
+
+output "coc_email_arn" {
+  value = aws_secretsmanager_secret.coc_email.arn
+}
+
+output "coc_password_arn" {
+  value = aws_secretsmanager_secret.coc_password.arn
+}

--- a/modules/secrets/variables.tf
+++ b/modules/secrets/variables.tf
@@ -22,3 +22,15 @@ variable "cookie_secure" {
   type    = bool
   default = true
 }
+
+variable "coc_email" {
+  description = "Clash of Clans developer portal email"
+  type        = string
+  sensitive   = true
+}
+
+variable "coc_password" {
+  description = "Clash of Clans developer portal password"
+  type        = string
+  sensitive   = true
+}

--- a/scripts/lower-env.sh
+++ b/scripts/lower-env.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lower environment suspend/resume helper
+# - Scales ECS services to 0 on suspend; restores on resume
+# - Stops/starts RDS instance (included by default)
+# - Stores previous desired counts and DB identifier under scripts/.env_state/<env>.json
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATE_DIR="$SCRIPT_DIR/.env_state"
+mkdir -p "$STATE_DIR"
+
+ts() { date '+%Y-%m-%dT%H:%M:%S%z'; }
+log() { echo "[$(ts)] [lower-env] $*"; }
+warn() { echo "[$(ts)] [lower-env][warn] $*" >&2; }
+err() { echo "[$(ts)] [lower-env][error] $*" >&2; exit 1; }
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || err "Missing required command: $1"; }
+
+usage() {
+  cat <<EOF
+Usage: $0 --env <dev|qa> --action <suspend|resume> [--skip-rds] [--plan-only] [--app-name <name>] [--aws-profile <profile>] [--timeout <sec>] [--interval <sec>] [--max-parallel <n>] [--sequential] [--resume-after-rds]
+
+Examples:
+  $0 --env dev --action suspend
+  $0 --env dev --action resume
+  $0 --env qa  --action suspend --plan-only
+
+Options:
+  --env <name>         Target environment directory under environments/ (dev or qa)
+  --action <op>        Operation to perform: suspend or resume
+  --skip-rds           Do not manage the RDS instance (defaults to included)
+  --plan-only          Show actions without executing
+  --app-name <name>    Override app name (otherwise discovered from Terraform vars)
+  --aws-profile <name> Use specific AWS CLI profile
+  --timeout <sec>      Max seconds to wait for each resource (default: 900)
+  --interval <sec>     Seconds between status checks (default: 10)
+  --max-parallel <n>   Max concurrent ECS service operations (default: 3)
+  --sequential         Disable parallel operations (equivalent to --max-parallel 1)
+  --resume-after-rds   Resume sequentially: start RDS and wait before ECS
+EOF
+}
+
+ENV_NAME=""
+ACTION=""
+INCLUDE_RDS=1
+PLAN_ONLY=0
+APP_NAME_OVERRIDE=""
+AWS_PROFILE=""
+TIMEOUT_SECS=900
+INTERVAL_SECS=10
+MAX_PARALLEL=3
+RESUME_AFTER_RDS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env) ENV_NAME="$2"; shift 2;;
+    --action) ACTION="$2"; shift 2;;
+    --skip-rds) INCLUDE_RDS=0; shift;;
+    --plan-only) PLAN_ONLY=1; shift;;
+    --app-name) APP_NAME_OVERRIDE="$2"; shift 2;;
+    --aws-profile) AWS_PROFILE="$2"; shift 2;;
+    --timeout) TIMEOUT_SECS="$2"; shift 2;;
+    --interval) INTERVAL_SECS="$2"; shift 2;;
+    --max-parallel) MAX_PARALLEL="$2"; shift 2;;
+    --sequential) MAX_PARALLEL=1; shift;;
+    --resume-after-rds) RESUME_AFTER_RDS=1; shift;;
+    -h|--help) usage; exit 0;;
+    *) err "Unknown argument: $1";;
+  esac
+done
+
+[[ -n "$ENV_NAME" ]] || { usage; err "--env is required"; }
+[[ -n "$ACTION" ]] || { usage; err "--action is required"; }
+[[ "$ENV_NAME" == "dev" || "$ENV_NAME" == "qa" ]] || err "--env must be 'dev' or 'qa'"
+[[ "$ACTION" == "suspend" || "$ACTION" == "resume" ]] || err "--action must be 'suspend' or 'resume'"
+
+need_cmd aws
+need_cmd jq
+
+ENV_DIR="$REPO_ROOT/environments/$ENV_NAME"
+[[ -d "$ENV_DIR" ]] || err "Environment directory not found: $ENV_DIR"
+
+STATE_FILE="$STATE_DIR/${ENV_NAME}.json"
+
+# Resolve app name from override or Terraform variables default
+resolve_app_name() {
+  if [[ -n "$APP_NAME_OVERRIDE" ]]; then
+    echo "$APP_NAME_OVERRIDE"
+    return
+  fi
+  local var_file="$ENV_DIR/variables.tf"
+  if [[ -f "$var_file" ]]; then
+    # Extract default value for variable "app_name"
+    local name
+    name=$(awk '/variable\s+"app_name"\s*{/,/}/ { if ($1=="default") { gsub("\"","",$3); print $3 } }' "$var_file" | tail -n1)
+    if [[ -n "$name" ]]; then
+      echo "$name"
+      return
+    fi
+  fi
+  err "Unable to determine app_name. Provide --app-name explicitly."
+}
+
+APP_NAME="$(resolve_app_name)"
+CLUSTER_NAME="${APP_NAME}-cluster"
+
+# AWS wrapper that respects optional profile
+aws_call() {
+  if [[ -n "${AWS_PROFILE:-}" ]]; then
+    aws --profile "$AWS_PROFILE" "$@"
+  else
+    aws "$@"
+  fi
+}
+
+# Limit number of concurrent background jobs to $MAX_PARALLEL
+throttle_jobs() {
+  # In some shells, jobs -pr may be empty; ensure non-negative integer
+  while :; do
+    local running
+    running=$(jobs -pr | wc -l | tr -d ' ')
+    [[ -z "$running" ]] && running=0
+    if (( running < MAX_PARALLEL )); then
+      break
+    fi
+    sleep 0.2
+  done
+}
+
+# Resolve DB endpoint from Terraform outputs (if present)
+get_db_endpoint() {
+  if command -v tofu >/dev/null 2>&1; then
+    (
+      cd "$ENV_DIR"
+      tofu output -json 2>/dev/null | jq -r '.db_endpoint.value // empty'
+    )
+  else
+    echo "" # tofu not installed
+  fi
+}
+
+# Resolve DB instance identifier either via endpoint match or name prefix
+get_db_instance_id() {
+  local endpoint="$1"
+  local id=""
+  if [[ -n "$endpoint" ]]; then
+    id=$(aws_call rds describe-db-instances --output json \
+      | jq -r --arg ep "$endpoint" '.DBInstances[] | select(.Endpoint.Address==$ep) | .DBInstanceIdentifier' | head -n1 || true)
+  fi
+  if [[ -z "$id" ]]; then
+    # Best-effort fallback by name prefix (unique per env)
+    id=$(aws_call rds describe-db-instances --output json \
+      | jq -r --arg pfx "${APP_NAME}-db-" '.DBInstances[] | select(.DBInstanceIdentifier|startswith($pfx)) | .DBInstanceIdentifier' | head -n1 || true)
+  fi
+  echo "$id"
+}
+
+# List expected ECS service names (known set in modules/ecs)
+expected_services() {
+  printf "%s\n" \
+    "${APP_NAME}-worker-svc" \
+    "${APP_NAME}-user-svc" \
+    "${APP_NAME}-messages-svc" \
+    "${APP_NAME}-notifications-svc" \
+    "${APP_NAME}-recruiting-svc"
+}
+
+aws_whoami() {
+  aws_call sts get-caller-identity --output json 2>/dev/null | jq -r '.Account + "@" + (.Arn|split(":")[3])' || echo "unknown"
+}
+
+update_service_desired() {
+  local svc="$1"; local desired="$2"
+  aws_call ecs update-service --cluster "$CLUSTER_NAME" --service "$svc" --desired-count "$desired" >/dev/null
+}
+
+describe_service_desired() {
+  local svc="$1"
+  aws_call ecs describe-services --cluster "$CLUSTER_NAME" --services "$svc" --output json \
+    | jq -r '.services[0].desiredCount // empty'
+}
+
+describe_service_counts() {
+  local svc="$1"
+  aws_call ecs describe-services --cluster "$CLUSTER_NAME" --services "$svc" --output json \
+    | jq -r '.services[0] | {desired: (.desiredCount // 0), running: (.runningCount // 0), pending: (.pendingCount // 0), status: (.status // "UNKNOWN"), deployments: ([.deployments[]?.rolloutState] // [])}'
+}
+
+wait_for_ecs_service() {
+  local svc="$1"; local target_desired="$2"
+  local start_ts=$(date +%s)
+  while true; do
+    local now=$(date +%s)
+    local elapsed=$(( now - start_ts ))
+    if (( elapsed > TIMEOUT_SECS )); then
+      warn "Timeout waiting for ECS $svc to reach desired=$target_desired"
+      return 1
+    fi
+    local json
+    if ! json=$(describe_service_counts "$svc" 2>/dev/null); then
+      warn "Failed to describe ECS service $svc"
+      sleep "$INTERVAL_SECS"; continue
+    fi
+    local desired running pending deployments status
+    desired=$(echo "$json" | jq -r '.desired')
+    running=$(echo "$json" | jq -r '.running')
+    pending=$(echo "$json" | jq -r '.pending')
+    status=$(echo "$json" | jq -r '.status')
+    deployments=$(echo "$json" | jq -r '.deployments | join(",")')
+    log "ECS $svc status: desired=$desired running=$running pending=$pending state=$status deployments=[$deployments]"
+    if [[ "$running" == "$target_desired" && "$pending" == "0" ]]; then
+      return 0
+    fi
+    sleep "$INTERVAL_SECS"
+  done
+}
+
+scale_and_wait() {
+  local svc="$1"; local target="$2"
+  log "Scaling $svc to $target"
+  if ! update_service_desired "$svc" "$target"; then
+    warn "Failed to scale $svc"
+    return 1
+  fi
+  if ! wait_for_ecs_service "$svc" "$target"; then
+    warn "ECS $svc did not reach desired=$target in time"
+    return 1
+  fi
+  return 0
+}
+
+rds_status() {
+  local id="$1"
+  aws_call rds describe-db-instances --db-instance-identifier "$id" --output json \
+    | jq -r '.DBInstances[0].DBInstanceStatus'
+}
+
+wait_for_rds_status() {
+  local id="$1"; local target="$2"
+  local start_ts=$(date +%s)
+  while true; do
+    local now=$(date +%s)
+    local elapsed=$(( now - start_ts ))
+    if (( elapsed > TIMEOUT_SECS )); then
+      warn "Timeout waiting for RDS $id status=$target"
+      return 1
+    fi
+    local st
+    st=$(rds_status "$id" 2>/dev/null || echo "unknown")
+    log "RDS $id status: $st (target: $target)"
+    if [[ "$st" == "$target" ]]; then
+      return 0
+    fi
+    sleep "$INTERVAL_SECS"
+  done
+}
+
+save_state() {
+  local ecs_services_json="$1"; shift
+  local db_id="$1"; shift
+  local db_status="$1"; shift
+  jq -n \
+    --arg env "$ENV_NAME" \
+    --arg app "$APP_NAME" \
+    --arg cluster "$CLUSTER_NAME" \
+    --arg dbid "$db_id" \
+    --arg dbst "$db_status" \
+    --arg ts "$(date -Iseconds)" \
+    --argjson services "$ecs_services_json" \
+    '{version:1, env:$env, app_name:$app, cluster_name:$cluster, saved_at:$ts, ecs:{services:$services}, rds:{db_instance_identifier:$dbid, status_before:$dbst}}' > "$STATE_FILE"
+}
+
+load_state() {
+  [[ -f "$STATE_FILE" ]] || err "State file not found: $STATE_FILE. Did you run suspend?"
+  cat "$STATE_FILE"
+}
+
+# Validate AWS caller for visibility
+log "AWS: $(aws_whoami)"
+log "Environment: $ENV_NAME | App: $APP_NAME | Cluster: $CLUSTER_NAME"
+log "Concurrency: max_parallel=$MAX_PARALLEL"
+
+case "$ACTION" in
+  suspend)
+    # Collect current desired counts into a temp file: "<svc> <desired>"
+    svc_tmp=$(mktemp)
+    > "$svc_tmp"
+    for svc in $(expected_services); do
+      if desired=$(describe_service_desired "$svc" 2>/dev/null); then
+        if [[ -n "$desired" && "$desired" != "null" ]]; then
+          printf "%s %s\n" "$svc" "$desired" >> "$svc_tmp"
+        else
+          warn "Service not found or no desiredCount: $svc (skipping)"
+        fi
+      else
+        warn "Service describe failed: $svc (skipping)"
+      fi
+    done
+
+    # Build JSON object of services -> desired from the temp file
+    ECS_SERVICES_JSON=$(awk '{printf("{\"%s\": %s}\n",$1,$2)}' "$svc_tmp" | jq -s 'add // {}')
+
+    DB_ENDPOINT=""
+    DB_ID=""
+    DB_STATUS=""
+    if [[ $INCLUDE_RDS -eq 1 ]]; then
+      DB_ENDPOINT="$(get_db_endpoint || true)"
+      DB_ID="$(get_db_instance_id "$DB_ENDPOINT" || true)"
+      if [[ -z "$DB_ID" ]]; then
+        warn "Could not resolve RDS instance identifier. Skipping RDS."
+        INCLUDE_RDS=0
+      else
+        DB_STATUS="$(rds_status "$DB_ID")"
+      fi
+    fi
+
+    log "Planned actions (suspend):"
+    while read -r line; do
+      [[ -z "$line" ]] && continue
+      svc_name=$(echo "$line" | awk '{print $1}')
+      desired_val=$(echo "$line" | awk '{print $2}')
+      log "- ECS service $svc_name: $desired_val -> 0"
+    done < "$svc_tmp"
+    if [[ $INCLUDE_RDS -eq 1 ]]; then
+      log "- RDS instance $DB_ID: $DB_STATUS -> stopped"
+    fi
+
+    if [[ $PLAN_ONLY -eq 1 ]]; then
+      log "Plan-only mode; no changes applied."
+      exit 0
+    fi
+
+    # Save state prior to changes
+    save_state "$ECS_SERVICES_JSON" "${DB_ID:-}" "${DB_STATUS:-}"
+    log "Saved state to $STATE_FILE"
+
+    # Apply ECS scaling (in parallel up to MAX_PARALLEL) and RDS stop in parallel
+    failures=0
+    pids=()
+    # Kick off RDS stop concurrently (if included)
+    if [[ $INCLUDE_RDS -eq 1 ]]; then
+      if [[ "$DB_STATUS" == "stopped" ]]; then
+        log "RDS $DB_ID already stopped"
+      else
+        (
+          log "Stopping RDS $DB_ID"
+          aws_call rds stop-db-instance --db-instance-identifier "$DB_ID" >/dev/null \
+            && wait_for_rds_status "$DB_ID" "stopped"
+        ) &
+        pids+=($!)
+      fi
+    fi
+
+    # Start ECS scale+wait tasks
+    while read -r line; do
+      [[ -z "$line" ]] && continue
+      svc_name=$(echo "$line" | awk '{print $1}')
+      desired_val=$(echo "$line" | awk '{print $2}')
+      if [[ "$desired_val" -gt 0 ]]; then
+        throttle_jobs
+        ( scale_and_wait "$svc_name" 0 ) &
+        pids+=($!)
+      else
+        log "Service $svc_name already at 0"
+      fi
+    done < "$svc_tmp"
+
+    rm -f "$svc_tmp"
+
+    # Wait for all background tasks and collect failures
+    for pid in "${pids[@]}"; do
+      if ! wait "$pid"; then
+        failures=$((failures+1))
+      fi
+    done
+
+    if [[ ${failures:-0} -gt 0 ]]; then
+      warn "Suspend completed with $failures failure(s)."
+      exit 1
+    fi
+    log "Suspend completed successfully."
+    ;;
+
+  resume)
+    STATE_JSON="$(load_state)"
+
+    SAVED_APP=$(echo "$STATE_JSON" | jq -r '.app_name')
+    [[ "$SAVED_APP" == "$APP_NAME" ]] || warn "App name mismatch (state=$SAVED_APP, current=$APP_NAME). Proceeding."
+
+  # Determine RDS plan (no actions yet; plan-only safe)
+  DB_ID=$(echo "$STATE_JSON" | jq -r '.rds.db_instance_identifier // empty')
+  failures=0
+  rds_pid=""
+  if [[ -n "$DB_ID" && $INCLUDE_RDS -eq 1 ]]; then
+    CUR_DB_STATUS=$(rds_status "$DB_ID" 2>/dev/null || echo "unknown")
+    if [[ $RESUME_AFTER_RDS -eq 1 ]]; then
+      log "Planned: RDS instance $DB_ID: ${CUR_DB_STATUS} -> available (sequential)"
+    else
+      log "Planned: RDS instance $DB_ID: ${CUR_DB_STATUS} -> available (eager)"
+    fi
+  fi
+
+    # Restore ECS services
+    KEYS=$(echo "$STATE_JSON" | jq -r '.ecs.services | keys[]' || true)
+
+    log "Planned actions (resume):"
+    for svc in $KEYS; do
+      cur=$(describe_service_desired "$svc" 2>/dev/null || echo "?")
+      target=$(echo "$STATE_JSON" | jq -r --arg k "$svc" '.ecs.services[$k]')
+      log "- ECS service $svc: ${cur} -> ${target}"
+    done
+
+  if [[ $PLAN_ONLY -eq 1 ]]; then
+    log "Plan-only mode; no changes applied."
+    exit 0
+  fi
+
+  if [[ $RESUME_AFTER_RDS -eq 1 ]]; then
+    # Sequential resume: ensure RDS is available first
+    if [[ -n "$DB_ID" && $INCLUDE_RDS -eq 1 ]]; then
+      CUR_DB_STATUS=${CUR_DB_STATUS:-unknown}
+      if [[ "$CUR_DB_STATUS" != "available" ]]; then
+        log "Starting RDS $DB_ID (sequential)"
+        if ! aws_call rds start-db-instance --db-instance-identifier "$DB_ID" >/dev/null; then
+          warn "Failed to start RDS $DB_ID"
+          failures=$((failures+1))
+        else
+          if ! wait_for_rds_status "$DB_ID" "available"; then
+            warn "RDS $DB_ID failed to start in time"
+            failures=$((failures+1))
+          fi
+        fi
+      else
+        log "RDS $DB_ID already available"
+      fi
+    fi
+
+    # Now scale ECS services in parallel
+    pids=()
+    for svc in $KEYS; do
+      target=$(echo "$STATE_JSON" | jq -r --arg k "$svc" '.ecs.services[$k]')
+      throttle_jobs
+      ( scale_and_wait "$svc" "$target" ) &
+      pids+=($!)
+    done
+    for pid in "${pids[@]}"; do
+      if ! wait "$pid"; then
+        failures=$((failures+1))
+      fi
+    done
+  else
+    # Eager resume: start RDS in background (if needed) and scale ECS concurrently
+    if [[ -n "$DB_ID" && $INCLUDE_RDS -eq 1 ]]; then
+      CUR_DB_STATUS=${CUR_DB_STATUS:-unknown}
+      if [[ "$CUR_DB_STATUS" != "available" ]]; then
+        (
+          log "Starting RDS $DB_ID (eager)"
+          aws_call rds start-db-instance --db-instance-identifier "$DB_ID" >/dev/null \
+            && wait_for_rds_status "$DB_ID" "available"
+        ) &
+        rds_pid=$!
+      else
+        log "RDS $DB_ID already available"
+      fi
+    fi
+
+    # Scale ECS services in parallel up to MAX_PARALLEL
+    pids=()
+    for svc in $KEYS; do
+      target=$(echo "$STATE_JSON" | jq -r --arg k "$svc" '.ecs.services[$k]')
+      throttle_jobs
+      ( scale_and_wait "$svc" "$target" ) &
+      pids+=($!)
+    done
+    # Also wait on RDS if we kicked it off
+    if [[ -n "$rds_pid" ]]; then
+      pids+=("$rds_pid")
+    fi
+    for pid in "${pids[@]}"; do
+      if ! wait "$pid"; then
+        failures=$((failures+1))
+      fi
+    done
+  fi
+
+    if [[ ${failures:-0} -gt 0 ]]; then
+      warn "Resume completed with $failures failure(s)."
+      exit 1
+    fi
+    log "Resume completed successfully."
+    ;;
+esac

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,11 @@ variable "backend_dynamodb_table" {
   type        = string
 }
 
+variable "lambda_artifacts_bucket" {
+  description = "S3 bucket for Lambda deployment artifacts"
+  type        = string
+}
+
 variable "frontend_bucket_name" {
   description = "S3 bucket to host the front-end"
   type        = string


### PR DESCRIPTION
## Summary
- Add lambda-artifacts module for S3 deployment bucket management
- Add refresh-worker module with CloudWatch scheduling and monitoring  
- Integrate CoC email/password secrets into all environments
- Add lower-env.sh script for environment suspend/resume operations

## Test plan
- [x] Terraform validation passes on all environments
- [x] Terraform formatting check passes
- [ ] Manual deployment test in dev environment
- [ ] Verify Lambda function execution with proper secrets access
- [ ] Test environment suspend/resume functionality

🤖 Generated with [Claude Code](https://claude.ai/code)